### PR TITLE
Prevent crash when using older configuration file

### DIFF
--- a/src/main/java/org/runejs/Configuration.java
+++ b/src/main/java/org/runejs/Configuration.java
@@ -45,6 +45,10 @@ public class Configuration {
             if (PASSWORD == null) {
                 PASSWORD = "";
             }
+            
+            if (SERVER_DISPLAY_NAME == null) {
+                SERVER_DISPLAY_NAME = "Build 435";
+            }
 
         } catch (Exception e) {
             System.out.println("Unable to load client config - using defaults.");


### PR DESCRIPTION
When using a configuration file from before SERVER_DISPLAY_NAME was a variable, the client will crash when attempting to open the console. This patch provides compatibility for this scenario.