### PR TITLE
refactor: remove a load of dummys, mostly from `MovedStatics` class

### DIFF
--- a/src/main/java/org/runejs/client/Class40_Sub5_Sub17_Sub6.java
+++ b/src/main/java/org/runejs/client/Class40_Sub5_Sub17_Sub6.java
@@ -117,9 +117,7 @@ public class Class40_Sub5_Sub17_Sub6 extends Renderable {
         return class40_sub5_sub17_sub5;
     }
 
-    public void method834(int arg0, int arg1) {
-        if(arg0 != 8076)
-            method834(106, 6);
+    public void method834(int arg1) {
         if(!aBoolean3237) {
             anInt3233 += arg1;
             while(anInt3233 > aAnimationSequence_3242.frameLengths[anInt3240]) {

--- a/src/main/java/org/runejs/client/Class43.java
+++ b/src/main/java/org/runejs/client/Class43.java
@@ -69,7 +69,7 @@ public class Class43 {
             MovedStatics.menuActionTypes[0] = 1005;
             ActorDefinition.menuActionRow = 1;
             if(GameInterface.fullscreenInterfaceId == -1) {
-                MovedStatics.method445(9767);
+                MovedStatics.method445();
                 Item.anInt3065 = -1;
                 OverlayDefinition.hoveredWidgetChildId = -1;
                 boolean bool = false;

--- a/src/main/java/org/runejs/client/Class43.java
+++ b/src/main/java/org/runejs/client/Class43.java
@@ -38,7 +38,7 @@ public class Class43 {
 
     public static void drawTabArea(int arg0) {
         MovedStatics.showSidePanelRedrawnText = true;
-        MovedStatics.method996(19655);
+        MovedStatics.method996();
         if(GameInterface.tabAreaInterfaceId != -1) {
             boolean bool = Main.drawParentInterface(1, 0, 0, 190, 261, GameInterface.tabAreaInterfaceId);
             if(!bool)

--- a/src/main/java/org/runejs/client/Class51.java
+++ b/src/main/java/org/runejs/client/Class51.java
@@ -6,7 +6,6 @@ import org.runejs.client.cache.media.gameInterface.GameInterface;
 import org.runejs.client.frame.ChatBox;
 import org.runejs.client.media.Rasterizer;
 import org.runejs.client.media.renderable.actor.Player;
-import org.runejs.client.node.HashTable;
 import org.runejs.client.scene.tile.GenericTile;
 import org.runejs.client.scene.tile.WallDecoration;
 
@@ -31,7 +30,7 @@ public class Class51 {
 
 
 
-    public static void method940(int arg0, String arg1, boolean arg2, String arg3) {
+    public static void method940(String arg1, boolean arg2, String arg3) {
         if(MovedStatics.clearScreen) {
             MovedStatics.clearScreen = false;
             ItemDefinition.drawWelcomeScreenGraphics();
@@ -39,7 +38,7 @@ public class Class51 {
             Class55.drawTabGraphics();
             ActorDefinition.drawMapBack();
             GenericTile.method943(ChatBox.tradeMode, WallDecoration.fontNormal, ChatBox.privateChatMode, ChatBox.publicChatMode);
-            MovedStatics.method527(Player.currentTabId, arg0 + 4, Player.tabWidgetIds, GameInterface.tabAreaInterfaceId == -1, -1);
+            MovedStatics.method527(Player.currentTabId, 4, Player.tabWidgetIds, GameInterface.tabAreaInterfaceId == -1, -1);
             MovedStatics.showSidePanelRedrawnText = true;
             Class40_Sub3.showIconsRedrawnText = true;
             MovedStatics.showChatPanelRedrawnText = true;
@@ -47,7 +46,7 @@ public class Class51 {
         int i = 151;
         Class65.method1018();
         i -= 3;
-        WallDecoration.fontNormal.drawStringLeft(arg1, 257, i, arg0);
+        WallDecoration.fontNormal.drawStringLeft(arg1, 257, i, 0);
         WallDecoration.fontNormal.drawStringLeft(arg1, 256, i + -1, 16777215);
         if(arg3 != null) {
             i += 15;
@@ -58,7 +57,7 @@ public class Class51 {
             WallDecoration.fontNormal.drawStringLeft(arg3, 257, i, 0);
             WallDecoration.fontNormal.drawStringLeft(arg3, 256, i - 1, 16777215);
         }
-        Player.drawGameScreenGraphics(arg0 + 107);
+        Player.drawGameScreenGraphics(107);
     }
 
     public static void clearModelCache() {

--- a/src/main/java/org/runejs/client/Class51.java
+++ b/src/main/java/org/runejs/client/Class51.java
@@ -38,7 +38,7 @@ public class Class51 {
             Class55.drawTabGraphics();
             ActorDefinition.drawMapBack();
             GenericTile.method943(ChatBox.tradeMode, WallDecoration.fontNormal, ChatBox.privateChatMode, ChatBox.publicChatMode);
-            MovedStatics.method527(Player.currentTabId, 4, Player.tabWidgetIds, GameInterface.tabAreaInterfaceId == -1, -1);
+            MovedStatics.method527(Player.currentTabId, Player.tabWidgetIds, GameInterface.tabAreaInterfaceId == -1, -1);
             MovedStatics.showSidePanelRedrawnText = true;
             Class40_Sub3.showIconsRedrawnText = true;
             MovedStatics.showChatPanelRedrawnText = true;

--- a/src/main/java/org/runejs/client/Class60.java
+++ b/src/main/java/org/runejs/client/Class60.java
@@ -254,7 +254,7 @@ public class Class60 {
                         Native.password = Configuration.getPassword();
                         Class26.loginScreenState = 0;
                     }
-                    while(MovedStatics.method416((byte) -104)) {
+                    while(MovedStatics.method416()) {
                         boolean bool = false;
                         for(int i_19_ = 0; Native.supportedCharacters.length() > i_19_; i_19_++) {
                             if(Native.supportedCharacters.charAt(i_19_) == Class59.anInt1388) {

--- a/src/main/java/org/runejs/client/Landscape.java
+++ b/src/main/java/org/runejs/client/Landscape.java
@@ -74,7 +74,7 @@ public class Landscape {
             }
             if(bool) {
                 if(ProducingGraphicsBuffer.anInt1634 != 0)
-                    Class51.method940(0, English.loadingPleaseWait, true, Native.aClass1_2423);
+                    Class51.method940(English.loadingPleaseWait, true, Native.aClass1_2423);
                 RSCanvas.clearCaches();
                 Npc.currentScene.initToNull();
                 System.gc();

--- a/src/main/java/org/runejs/client/Landscape.java
+++ b/src/main/java/org/runejs/client/Landscape.java
@@ -107,7 +107,7 @@ public class Landscape {
                         int offsetY = -Class26.baseY + 64 * (ISAAC.mapCoordinates[pointer] & 0xff);
                         byte[] data = RSString.terrainData[pointer];
                         if(data == null && Class17.regionY < 800)
-                            MovedStatics.initiateVertexHeights(offsetY, (byte) 103, 64, 64, offsetX);
+                            MovedStatics.initiateVertexHeights(offsetY, 64, 64, offsetX);
                     }
                     Main.method364(true);
                     for(int region = 0; dataLength > region; region++) {
@@ -163,7 +163,7 @@ public class Landscape {
                         for(int y = 0; y < 13; y++) {
                             int displayMap = OverlayDefinition.constructMapTiles[0][x][y];
                             if(displayMap == -1)
-                                MovedStatics.initiateVertexHeights(y * 8, (byte) 120, 8, 8, 8 * x);
+                                MovedStatics.initiateVertexHeights(y * 8, 8, 8, 8 * x);
                         }
                     }
                     Main.method364(true);

--- a/src/main/java/org/runejs/client/LinkedList.java
+++ b/src/main/java/org/runejs/client/LinkedList.java
@@ -65,7 +65,7 @@ public class LinkedList {
                 Actor.method789(Player.localPlayer.pathY[0], -1000, Class17.regionY, Class51.regionX, Player.localPlayer.pathX[0], Player.worldLevel);
             else if(Buffer.anInt1985 != Player.worldLevel) {
                 Buffer.anInt1985 = Player.worldLevel;
-                MovedStatics.method299((byte) 53, Player.worldLevel);
+                MovedStatics.method299(Player.worldLevel);
             }
         }
     }

--- a/src/main/java/org/runejs/client/Main.java
+++ b/src/main/java/org/runejs/client/Main.java
@@ -771,7 +771,7 @@ public class Main extends GameShell {
         ItemDefinition.method749(true);
         Class40_Sub5_Sub17_Sub6.method833(0, false);
         ItemDefinition.method749(false);
-        MovedStatics.method335((byte) 61);
+        MovedStatics.method335();
         MovedStatics.method1000(true);
         if(!Player.cutsceneActive) {
             int i = Class65.cameraVertical;

--- a/src/main/java/org/runejs/client/Main.java
+++ b/src/main/java/org/runejs/client/Main.java
@@ -830,7 +830,7 @@ public class Main extends GameShell {
         Npc.currentScene.render(Class12.cameraX, SceneCluster.cameraZ, MovedStatics.cameraY, Class26.anInt627, ProducingGraphicsBuffer_Sub1.anInt2210, i);
         Npc.currentScene.clearInteractiveObjectCache();
         Class33.method404();
-        MovedStatics.method450((byte) -67);
+        MovedStatics.method450();
         ((Class35) Rasterizer3D.interface3).method425((byte) 6, MovedStatics.anInt199);
         KeyFocusListener.draw3dScreen();
 

--- a/src/main/java/org/runejs/client/Main.java
+++ b/src/main/java/org/runejs/client/Main.java
@@ -1018,7 +1018,7 @@ public class Main extends GameShell {
                 }
                 GameInterface.drawTabIcons = false;
                 Class40_Sub3.showIconsRedrawnText = true;
-                MovedStatics.method527(Player.currentTabId, 4, Player.tabWidgetIds, GameInterface.tabAreaInterfaceId == -1, MovedStatics.pulseCycle % 20 >= 10 ? Class51.anInt1205 : -1);
+                MovedStatics.method527(Player.currentTabId, Player.tabWidgetIds, GameInterface.tabAreaInterfaceId == -1, MovedStatics.pulseCycle % 20 >= 10 ? Class51.anInt1205 : -1);
             }
             if(MovedStatics.redrawChatbox) {
                 Class40_Sub3.showIconsRedrawnText = true;
@@ -1062,7 +1062,7 @@ public class Main extends GameShell {
                 }
                 GameInterface.drawTabIcons = false;
                 Class40_Sub3.showIconsRedrawnText = true;
-                MovedStatics.method527(Player.currentTabId, 4, Player.tabWidgetIds, GameInterface.tabAreaInterfaceId == -1, MovedStatics.pulseCycle % 20 >= 10 ? Class51.anInt1205 : -1);
+                MovedStatics.method527(Player.currentTabId, Player.tabWidgetIds, GameInterface.tabAreaInterfaceId == -1, MovedStatics.pulseCycle % 20 >= 10 ? Class51.anInt1205 : -1);
             }
             if(MovedStatics.redrawChatbox) {
                 Class40_Sub3.showIconsRedrawnText = true;

--- a/src/main/java/org/runejs/client/Main.java
+++ b/src/main/java/org/runejs/client/Main.java
@@ -772,7 +772,7 @@ public class Main extends GameShell {
         Class40_Sub5_Sub17_Sub6.method833(0, false);
         ItemDefinition.method749(false);
         MovedStatics.method335();
-        MovedStatics.method1000(true);
+        MovedStatics.method1000();
         if(!Player.cutsceneActive) {
             int i = Class65.cameraVertical;
             if(MovedStatics.secondaryCameraVertical / 256 > i) {

--- a/src/main/java/org/runejs/client/Main.java
+++ b/src/main/java/org/runejs/client/Main.java
@@ -788,7 +788,7 @@ public class Main extends GameShell {
         if(!Player.cutsceneActive) {
             i = Projectile.method764((byte) -107);
         } else {
-            i = MovedStatics.method546(256);
+            i = MovedStatics.method546();
         }
         int i_1_ = Class12.cameraX;
         int i_2_ = ProducingGraphicsBuffer_Sub1.anInt2210;

--- a/src/main/java/org/runejs/client/Main.java
+++ b/src/main/java/org/runejs/client/Main.java
@@ -2057,7 +2057,7 @@ public class Main extends GameShell {
         OverlayDefinition.gameServerPort = Class44.modewhere != 0 ? Player.worldId + 40000 : Configuration.GAME_PORT;
         currentPort = OverlayDefinition.gameServerPort;
 
-        MovedStatics.method997(47);
+        MovedStatics.method997();
         GameInterface.method642(MouseHandler.gameCanvas, -10);
         RSRuntimeException.method1056(MouseHandler.gameCanvas, (byte) 70);
         RSCanvas.anInt57 = Signlink.anInt737;

--- a/src/main/java/org/runejs/client/Main.java
+++ b/src/main/java/org/runejs/client/Main.java
@@ -1259,7 +1259,7 @@ public class Main extends GameShell {
                 if(ISAAC.aBoolean519 && Class51.gameStatusCode == 30) {
                     MouseHandler.currentMouseButtonPressed = 0;
                     MouseHandler.clickType = 0;
-                    while(MovedStatics.method416((byte) -104)) {
+                    while(MovedStatics.method416()) {
                         /* empty */
                     }
                     for(int i = 0; i < Item.obfuscatedKeyStatus.length; i++)

--- a/src/main/java/org/runejs/client/Main.java
+++ b/src/main/java/org/runejs/client/Main.java
@@ -850,7 +850,7 @@ public class Main extends GameShell {
         if(ISAAC.aBoolean519) {
             Class65.method1018();
             Rasterizer.resetPixels();
-            Class51.method940(0, English.loadingPleaseWait, false, null);
+            Class51.method940(English.loadingPleaseWait, false, null);
         }
 
         Player.drawGameScreenGraphics(110);
@@ -1924,21 +1924,21 @@ public class Main extends GameShell {
                 if (Class37.anInt874 > PacketBuffer.anInt2231)
                     PacketBuffer.anInt2231 = Class37.anInt874;
                 int i = (-Class37.anInt874 + PacketBuffer.anInt2231) * 50 / PacketBuffer.anInt2231;
-                Class51.method940(0, English.loadingPleaseWait, true, Native.leftParenthesis + i + Native.aClass1_698);
+                Class51.method940(English.loadingPleaseWait, true, Native.leftParenthesis + i + Native.aClass1_698);
             } else if (ProducingGraphicsBuffer.anInt1634 == 2) {
                 if (IdentityKit.anInt2591 > GameObject.anInt3048)
                     GameObject.anInt3048 = IdentityKit.anInt2591;
                 int i = 50 * (-IdentityKit.anInt2591 + GameObject.anInt3048) / GameObject.anInt3048 + 50;
-                Class51.method940(0, English.loadingPleaseWait, true, Native.leftParenthesis + i + Native.aClass1_698);
+                Class51.method940(English.loadingPleaseWait, true, Native.leftParenthesis + i + Native.aClass1_698);
             } else
-                Class51.method940(0, English.loadingPleaseWait, false, null);
+                Class51.method940(English.loadingPleaseWait, false, null);
         } else if (Class51.gameStatusCode == 30) {
             drawGameScreen();
 
         } else if (Class51.gameStatusCode == 35) {
             method164();
         } else if (Class51.gameStatusCode == 40)
-            Class51.method940(0, English.connectionLost, false, English.pleaseWaitAttemptingToReestablish);
+            Class51.method940(English.connectionLost, false, English.pleaseWaitAttemptingToReestablish);
         Npc.anInt3294 = 0;
     }
 

--- a/src/main/java/org/runejs/client/MovedStatics.java
+++ b/src/main/java/org/runejs/client/MovedStatics.java
@@ -655,7 +655,7 @@ public class MovedStatics {
         return GenericTile.method944((byte) -3, i, arg0, i_4_);
     }
 
-    public static void method527(int currentTabId, int arg1, int[] tabWidgetIds, boolean arg3, int arg4) {
+    public static void method527(int currentTabId, int[] tabWidgetIds, boolean arg3, int arg4) {
         InteractiveObject.tabTop.prepareRasterizer();
         Buffer.tabTopBack.drawImage(0, 0);
         if (arg3) {
@@ -692,7 +692,7 @@ public class MovedStatics {
         }
         RSCanvas.tabBottom.prepareRasterizer();
         tabBottomBack.drawImage(0, 0);
-        if (arg1 != 4)
+        if (4 != 4)
             Player.hasFriend(null);
         if (arg3) {
             if (tabWidgetIds[currentTabId] != -1) {

--- a/src/main/java/org/runejs/client/MovedStatics.java
+++ b/src/main/java/org/runejs/client/MovedStatics.java
@@ -225,9 +225,7 @@ public class MovedStatics {
         }
     }
 
-    public static void method996(int arg0) {
-        if (arg0 != 19655)
-            English.systemUpdateIn = null;
+    public static void method996() {
         tabImageProducer.prepareRasterizer();
         if (ScreenController.frameMode == ScreenMode.FIXED) {
             FloorDecoration.inventoryBackgroundImage.drawImage(0, 0);

--- a/src/main/java/org/runejs/client/MovedStatics.java
+++ b/src/main/java/org/runejs/client/MovedStatics.java
@@ -735,14 +735,12 @@ public class MovedStatics {
         }
     }
 
-    public static boolean method416(byte arg0) {
+    public static boolean method416() {
         synchronized (Class59.keyFocusListener) {
             if (Class59.anInt1389 == GenericTile.anInt1214)
                 return false;
             ItemDefinition.anInt2854 = anIntArray2113[Class59.anInt1389];
             Class59.anInt1388 = anIntArray2764[Class59.anInt1389];
-            if (arg0 > -21)
-                English.clickToContinue = null;
             Class59.anInt1389 = Class59.anInt1389 + 1 & 0x7f;
             return true;
         }
@@ -1494,7 +1492,7 @@ public class MovedStatics {
 	}
 
 	public static void manageTextInputs() {
-	    while(method416((byte) -125)) {
+	    while(method416()) {
 	        if(ItemDefinition.anInt2854 == 28) {
 	            break;
 	        }

--- a/src/main/java/org/runejs/client/MovedStatics.java
+++ b/src/main/java/org/runejs/client/MovedStatics.java
@@ -748,7 +748,7 @@ public class MovedStatics {
         }
     }
 
-    public static int mixLightnessSigned(int hsl, int lightness, boolean junk) {
+    public static int mixLightnessSigned(int hsl, int lightness) {
         if (hsl == -2)
             return 12345678;
             
@@ -760,9 +760,6 @@ public class MovedStatics {
             lightness = -lightness + 127;
             return lightness;
         }
-
-        if (!junk)
-            UpdateServer.calculateDataLoaded(-124, -88);
 
         lightness = lightness * (hsl & 0x7f) / 128;
         if (lightness < 2)

--- a/src/main/java/org/runejs/client/MovedStatics.java
+++ b/src/main/java/org/runejs/client/MovedStatics.java
@@ -369,11 +369,9 @@ public class MovedStatics {
             tile_height[arg1][arg3][arg0] = tile_height[arg1][-1 + arg3][arg0 - 1];
     }
 
-    public static boolean method459(int arg0, int arg1, byte arg2) {
+    public static boolean method459(int arg0, int arg1) {
         if (arg0 == 11)
             arg0 = 10;
-        if (arg2 < 83)
-            method459(125, 22, (byte) 101);
         GameObjectDefinition gameObjectDefinition = GameObjectDefinition.getDefinition(arg1);
         if (arg0 >= 5 && arg0 <= 8)
             arg0 = 4;
@@ -1103,14 +1101,14 @@ public class MovedStatics {
             if(class40_sub3.anInt2031 > 0)
                 class40_sub3.anInt2031--;
             if(class40_sub3.anInt2031 == 0) {
-                if(class40_sub3.anInt2028 < 0 || method459(class40_sub3.anInt2036, class40_sub3.anInt2028, (byte) 103)) {
+                if(class40_sub3.anInt2028 < 0 || method459(class40_sub3.anInt2036, class40_sub3.anInt2028)) {
                     GenericTile.method945(class40_sub3.anInt2038, class40_sub3.anInt2028, class40_sub3.anInt2039, class40_sub3.anInt2036, class40_sub3.anInt2025, 103, class40_sub3.anInt2027, class40_sub3.anInt2018);
                     class40_sub3.unlink();
                 }
             } else {
                 if(class40_sub3.anInt2033 > 0)
                     class40_sub3.anInt2033--;
-                if(class40_sub3.anInt2033 == 0 && class40_sub3.anInt2039 >= 1 && class40_sub3.anInt2038 >= 1 && class40_sub3.anInt2039 <= 102 && class40_sub3.anInt2038 <= 102 && (class40_sub3.anInt2017 < 0 || method459(class40_sub3.anInt2030, class40_sub3.anInt2017, (byte) 106))) {
+                if(class40_sub3.anInt2033 == 0 && class40_sub3.anInt2039 >= 1 && class40_sub3.anInt2038 >= 1 && class40_sub3.anInt2039 <= 102 && class40_sub3.anInt2038 <= 102 && (class40_sub3.anInt2017 < 0 || method459(class40_sub3.anInt2030, class40_sub3.anInt2017))) {
                     GenericTile.method945(class40_sub3.anInt2038, class40_sub3.anInt2017, class40_sub3.anInt2039, class40_sub3.anInt2030, class40_sub3.anInt2035, 103, class40_sub3.anInt2027, class40_sub3.anInt2018);
                     class40_sub3.anInt2033 = -1;
                     if(class40_sub3.anInt2028 == class40_sub3.anInt2017 && class40_sub3.anInt2028 == -1)

--- a/src/main/java/org/runejs/client/MovedStatics.java
+++ b/src/main/java/org/runejs/client/MovedStatics.java
@@ -252,7 +252,7 @@ public class MovedStatics {
 
     public static void method997(int arg0) {
         if (arg0 != 47)
-            initiateVertexHeights(-42, (byte) 12, 92, 18, -72);
+            initiateVertexHeights(-42, 92, 18, -72);
         if (Signlink.javaVendor.toLowerCase().indexOf("microsoft") == -1) {
             HuffmanEncoding.anIntArray1564[44] = 71;
             HuffmanEncoding.anIntArray1564[45] = 26;
@@ -288,8 +288,7 @@ public class MovedStatics {
 
     }
 
-    public static void initiateVertexHeights(int offsetY, byte arg1, int sizeY, int sizeX, int offsetX) {
-        int i = -112 / ((50 - arg1) / 53);
+    public static void initiateVertexHeights(int offsetY, int sizeY, int sizeX, int offsetX) {
         for (int y = offsetY; y <= offsetY + sizeY; y++) {
             for (int x = offsetX; sizeX + offsetX >= x; x++) {
                 if (x >= 0 && x < 104 && y >= 0 && y < 104) {

--- a/src/main/java/org/runejs/client/MovedStatics.java
+++ b/src/main/java/org/runejs/client/MovedStatics.java
@@ -307,20 +307,18 @@ public class MovedStatics {
         }
     }
 
-    public static void method1000(boolean arg0) {
-        if (arg0) {
-            for (Class40_Sub5_Sub17_Sub6 class40_sub5_sub17_sub6 = (Class40_Sub5_Sub17_Sub6) Class57.aLinkedList_1332.peekFirst((byte) -90); class40_sub5_sub17_sub6 != null; class40_sub5_sub17_sub6 = (Class40_Sub5_Sub17_Sub6) Class57.aLinkedList_1332.pollFirst(-4)) {
-                if (Player.worldLevel == class40_sub5_sub17_sub6.anInt3239 && !class40_sub5_sub17_sub6.aBoolean3237) {
-                    if (pulseCycle >= class40_sub5_sub17_sub6.anInt3230) {
-                        class40_sub5_sub17_sub6.method834(8076, anInt199);
-                        if (class40_sub5_sub17_sub6.aBoolean3237)
-                            class40_sub5_sub17_sub6.unlink();
-                        else
-                            Npc.currentScene.method134(class40_sub5_sub17_sub6.anInt3239, class40_sub5_sub17_sub6.anInt3244, class40_sub5_sub17_sub6.anInt3235, class40_sub5_sub17_sub6.anInt3231, 60, class40_sub5_sub17_sub6, 0, -1, false);
-                    }
-                } else
-                    class40_sub5_sub17_sub6.unlink();
-            }
+    public static void method1000() {
+        for (Class40_Sub5_Sub17_Sub6 class40_sub5_sub17_sub6 = (Class40_Sub5_Sub17_Sub6) Class57.aLinkedList_1332.peekFirst((byte) -90); class40_sub5_sub17_sub6 != null; class40_sub5_sub17_sub6 = (Class40_Sub5_Sub17_Sub6) Class57.aLinkedList_1332.pollFirst(-4)) {
+            if (Player.worldLevel == class40_sub5_sub17_sub6.anInt3239 && !class40_sub5_sub17_sub6.aBoolean3237) {
+                if (pulseCycle >= class40_sub5_sub17_sub6.anInt3230) {
+                    class40_sub5_sub17_sub6.method834(8076, anInt199);
+                    if (class40_sub5_sub17_sub6.aBoolean3237)
+                        class40_sub5_sub17_sub6.unlink();
+                    else
+                        Npc.currentScene.method134(class40_sub5_sub17_sub6.anInt3239, class40_sub5_sub17_sub6.anInt3244, class40_sub5_sub17_sub6.anInt3235, class40_sub5_sub17_sub6.anInt3231, 60, class40_sub5_sub17_sub6, 0, -1, false);
+                }
+            } else
+                class40_sub5_sub17_sub6.unlink();
         }
     }
 

--- a/src/main/java/org/runejs/client/MovedStatics.java
+++ b/src/main/java/org/runejs/client/MovedStatics.java
@@ -1924,10 +1924,8 @@ public class MovedStatics {
 	    return class40_sub5_sub14_sub2s;
 	}
 
-	public static ImageRGB[] method319(byte arg0) {
+	public static ImageRGB[] method319() {
 	    ImageRGB[] class40_sub5_sub14_sub4s = new ImageRGB[anInt2581];
-	    if(arg0 != -62)
-	        return null;
 	    for(int i = 0; i < anInt2581; i++) {
 	        ImageRGB class40_sub5_sub14_sub4 = class40_sub5_sub14_sub4s[i] = new ImageRGB();
 	        class40_sub5_sub14_sub4.maxWidth = ItemDefinition.anInt2846;

--- a/src/main/java/org/runejs/client/MovedStatics.java
+++ b/src/main/java/org/runejs/client/MovedStatics.java
@@ -633,18 +633,16 @@ public class MovedStatics {
         }
     }
 
-    public static void method838(int arg0, long arg1) {
-        if (arg1 != 0) {
-            for (int i = arg0; i < anInt1008; i++) {
-                if (Player.ignores[i] == arg1) {
-                    GameInterface.redrawTabArea = true;
-                    anInt1008--;
-                    for (int i_16_ = i; anInt1008 > i_16_; i_16_++)
-                        Player.ignores[i_16_] = Player.ignores[1 + i_16_];
-                    SceneCluster.packetBuffer.putPacket(28);
-                    SceneCluster.packetBuffer.putLongBE(arg1);
-                    break;
-                }
+    public static void method838(long arg1) {
+        for (int i = 0; i < anInt1008; i++) {
+            if (Player.ignores[i] == arg1) {
+                GameInterface.redrawTabArea = true;
+                anInt1008--;
+                for (int i_16_ = i; anInt1008 > i_16_; i_16_++)
+                    Player.ignores[i_16_] = Player.ignores[1 + i_16_];
+                SceneCluster.packetBuffer.putPacket(28);
+                SceneCluster.packetBuffer.putLongBE(arg1);
+                break;
             }
         }
     }
@@ -1548,7 +1546,7 @@ public class MovedStatics {
 	                }
 	                if(Class37.anInt876 == 5 && anInt1008 > 0) {
 	                    long l = RSString.nameToLong(ChatBox.chatMessage);
-	                    method838(0, l);
+	                    method838(l);
 	                }
 	            }
 	        } else if(ChatBox.inputType == 1) {

--- a/src/main/java/org/runejs/client/MovedStatics.java
+++ b/src/main/java/org/runejs/client/MovedStatics.java
@@ -324,12 +324,10 @@ public class MovedStatics {
         }
     }
 
-    public static int method546(int arg0) {
+    public static int method546() {
         if (!Configuration.ROOFS_ENABLED) {
             return Player.worldLevel;
         }
-        if (arg0 != 256)
-            anInt2280 = 44;
         int i = Class37.getFloorDrawHeight(Player.worldLevel, Class12.cameraX, MovedStatics.cameraY);
         if (i + -SceneCluster.cameraZ < 800 && (OverlayDefinition.tile_flags[Player.worldLevel][Class12.cameraX >> 7][MovedStatics.cameraY >> 7] & 0x4) != 0)
             return Player.worldLevel;

--- a/src/main/java/org/runejs/client/MovedStatics.java
+++ b/src/main/java/org/runejs/client/MovedStatics.java
@@ -336,10 +336,8 @@ public class MovedStatics {
         return 3;
     }
 
-    public static void method233(boolean arg0) {
+    public static void method233() {
         OverlayDefinition.overlayDefinitionCache.clear();
-        if (!arg0)
-            initializeAnimationCaches(null, null, null);
     }
 
     public static void initializeAnimationCaches(CacheArchive skinArchive, CacheArchive definitionArchive, CacheArchive skeletonArchive) {

--- a/src/main/java/org/runejs/client/MovedStatics.java
+++ b/src/main/java/org/runejs/client/MovedStatics.java
@@ -1836,7 +1836,7 @@ public class MovedStatics {
 	        chatboxLineOffsets = Rasterizer3D.setLineOffsets(chatboxLineOffsets);
 	    }
 
-	public static void method299(byte arg0, int arg1) {
+	public static void method299(int arg1) {
 	    int[] is = minimapImage.pixels;
 	    int i = is.length;
 	    for(int i_0_ = 0; i > i_0_; i_0_++)
@@ -1863,8 +1863,6 @@ public class MovedStatics {
 	        }
 	    }
 	    GameObject.minimapHintCount = 0;
-	    if(arg0 < 24)
-	        Player.trackedPlayerAppearanceCache = null;
 	    for(int i_8_ = 0; i_8_ < 104; i_8_++) {
 	        for(int i_9_ = 0; i_9_ < 104; i_9_++) {
 	            int i_10_ = Npc.currentScene.getFloorDecorationHash(Player.worldLevel, i_8_, i_9_);

--- a/src/main/java/org/runejs/client/MovedStatics.java
+++ b/src/main/java/org/runejs/client/MovedStatics.java
@@ -250,9 +250,8 @@ public class MovedStatics {
         ActorDefinition.sidebarOffsets = Rasterizer3D.setLineOffsets(ActorDefinition.sidebarOffsets);
     }
 
-    public static void method997(int arg0) {
-        if (arg0 != 47)
-            initiateVertexHeights(-42, 92, 18, -72);
+    public static void method997() {
+        // (Jameskmonger) I think this is something to do with keycode remapping, though Im not sure
         if (Signlink.javaVendor.toLowerCase().indexOf("microsoft") == -1) {
             HuffmanEncoding.anIntArray1564[44] = 71;
             HuffmanEncoding.anIntArray1564[45] = 26;

--- a/src/main/java/org/runejs/client/MovedStatics.java
+++ b/src/main/java/org/runejs/client/MovedStatics.java
@@ -311,7 +311,7 @@ public class MovedStatics {
         for (Class40_Sub5_Sub17_Sub6 class40_sub5_sub17_sub6 = (Class40_Sub5_Sub17_Sub6) Class57.aLinkedList_1332.peekFirst((byte) -90); class40_sub5_sub17_sub6 != null; class40_sub5_sub17_sub6 = (Class40_Sub5_Sub17_Sub6) Class57.aLinkedList_1332.pollFirst(-4)) {
             if (Player.worldLevel == class40_sub5_sub17_sub6.anInt3239 && !class40_sub5_sub17_sub6.aBoolean3237) {
                 if (pulseCycle >= class40_sub5_sub17_sub6.anInt3230) {
-                    class40_sub5_sub17_sub6.method834(8076, anInt199);
+                    class40_sub5_sub17_sub6.method834(anInt199);
                     if (class40_sub5_sub17_sub6.aBoolean3237)
                         class40_sub5_sub17_sub6.unlink();
                     else

--- a/src/main/java/org/runejs/client/MovedStatics.java
+++ b/src/main/java/org/runejs/client/MovedStatics.java
@@ -1953,10 +1953,8 @@ public class MovedStatics {
 	    arg1.removeFocusListener(Class59.keyFocusListener);
 	}
 
-	public static void method450(byte arg0) {
+	public static void method450() {
 	    if (Player.headIconDrawType == 2) {
-	        if (arg0 >= -28)
-	            method445(-128);
 	        MovedStatics.method312(2 * ActorDefinition.anInt2404, Class35.anInt1730 + (-Class26.baseY + anInt175 << 7), (ProducingGraphicsBuffer.anInt1637 + -baseX << 7) + Landscape.anInt1170, 4976905);
 	        if (ISAAC.anInt522 > -1 && pulseCycle % 20 < 10)
 	            aClass40_Sub5_Sub14_Sub4Array2567[0].drawImage(ISAAC.anInt522 + -12, -28 + Class44.anInt1048);

--- a/src/main/java/org/runejs/client/MovedStatics.java
+++ b/src/main/java/org/runejs/client/MovedStatics.java
@@ -375,7 +375,7 @@ public class MovedStatics {
         GameObjectDefinition gameObjectDefinition = GameObjectDefinition.getDefinition(arg1);
         if (arg0 >= 5 && arg0 <= 8)
             arg0 = 4;
-        return gameObjectDefinition.method610(arg0, 7533);
+        return gameObjectDefinition.method610(arg0);
     }
 
     public static IndexedImage method538(int arg0) {

--- a/src/main/java/org/runejs/client/MovedStatics.java
+++ b/src/main/java/org/runejs/client/MovedStatics.java
@@ -184,7 +184,7 @@ public class MovedStatics {
     public static IndexedImage aClass40_Sub5_Sub14_Sub2_1919;
     public static int anInt1923 = 0;
 
-    public static void method445(int arg0) {
+    public static void method445() {
         if (CollisionMap.anInt165 != 0) {
             int i = 0;
             if (Class40_Sub5_Sub15.systemUpdateTime != 0)
@@ -220,8 +220,6 @@ public class MovedStatics {
                         return;
                 }
             }
-            if (arg0 != 9767)
-                anInt1923 = 48;
         }
     }
 

--- a/src/main/java/org/runejs/client/MovedStatics.java
+++ b/src/main/java/org/runejs/client/MovedStatics.java
@@ -410,33 +410,31 @@ public class MovedStatics {
         return PacketBuffer.method521(false, 10, arg0);
     }
 
-    public static void method335(byte arg0) {
+    public static void method335() {
         Projectile projectile = (Projectile) Class43.projectileQueue.peekFirst((byte) -90);
-        if (arg0 == 61) {
-            for (/**/; projectile != null; projectile = (Projectile) Class43.projectileQueue.pollFirst(arg0 + -65)) {
-                if (Player.worldLevel == projectile.anInt2981 && pulseCycle <= projectile.endCycle) {
-                    if (projectile.delay <= pulseCycle) {
-                        if (projectile.entityIndex > 0) {
-                            Npc class40_sub5_sub17_sub4_sub2 = Player.npcs[-1 + projectile.entityIndex];
-                            if (class40_sub5_sub17_sub4_sub2 != null && class40_sub5_sub17_sub4_sub2.worldX >= 0 && class40_sub5_sub17_sub4_sub2.worldX < 13312 && class40_sub5_sub17_sub4_sub2.worldY >= 0 && class40_sub5_sub17_sub4_sub2.worldY < 13312)
-                                projectile.trackTarget(pulseCycle, arg0 + -61, class40_sub5_sub17_sub4_sub2.worldY, Class37.getFloorDrawHeight(projectile.anInt2981, class40_sub5_sub17_sub4_sub2.worldX, class40_sub5_sub17_sub4_sub2.worldY) - projectile.endHeight, class40_sub5_sub17_sub4_sub2.worldX);
-                        }
-                        if (projectile.entityIndex < 0) {
-                            int i = -1 + -projectile.entityIndex;
-                            Player class40_sub5_sub17_sub4_sub1;
-                            if (i != PlayerAppearance.anInt708)
-                                class40_sub5_sub17_sub4_sub1 = Player.trackedPlayers[i];
-                            else
-                                class40_sub5_sub17_sub4_sub1 = Player.localPlayer;
-                            if (class40_sub5_sub17_sub4_sub1 != null && class40_sub5_sub17_sub4_sub1.worldX >= 0 && class40_sub5_sub17_sub4_sub1.worldX < 13312 && class40_sub5_sub17_sub4_sub1.worldY >= 0 && class40_sub5_sub17_sub4_sub1.worldY < 13312)
-                                projectile.trackTarget(pulseCycle, 0, class40_sub5_sub17_sub4_sub1.worldY, Class37.getFloorDrawHeight(projectile.anInt2981, class40_sub5_sub17_sub4_sub1.worldX, class40_sub5_sub17_sub4_sub1.worldY) - projectile.endHeight, class40_sub5_sub17_sub4_sub1.worldX);
-                        }
-                        projectile.move(anInt199);
-                        Npc.currentScene.method134(Player.worldLevel, (int) projectile.currentX, (int) projectile.currentY, (int) projectile.currentHeight, 60, projectile, projectile.anInt3013, -1, false);
+        for (/**/; projectile != null; projectile = (Projectile) Class43.projectileQueue.pollFirst(61 + -65)) {
+            if (Player.worldLevel == projectile.anInt2981 && pulseCycle <= projectile.endCycle) {
+                if (projectile.delay <= pulseCycle) {
+                    if (projectile.entityIndex > 0) {
+                        Npc class40_sub5_sub17_sub4_sub2 = Player.npcs[-1 + projectile.entityIndex];
+                        if (class40_sub5_sub17_sub4_sub2 != null && class40_sub5_sub17_sub4_sub2.worldX >= 0 && class40_sub5_sub17_sub4_sub2.worldX < 13312 && class40_sub5_sub17_sub4_sub2.worldY >= 0 && class40_sub5_sub17_sub4_sub2.worldY < 13312)
+                            projectile.trackTarget(pulseCycle, 61 + -61, class40_sub5_sub17_sub4_sub2.worldY, Class37.getFloorDrawHeight(projectile.anInt2981, class40_sub5_sub17_sub4_sub2.worldX, class40_sub5_sub17_sub4_sub2.worldY) - projectile.endHeight, class40_sub5_sub17_sub4_sub2.worldX);
                     }
-                } else
-                    projectile.unlink();
-            }
+                    if (projectile.entityIndex < 0) {
+                        int i = -1 + -projectile.entityIndex;
+                        Player class40_sub5_sub17_sub4_sub1;
+                        if (i != PlayerAppearance.anInt708)
+                            class40_sub5_sub17_sub4_sub1 = Player.trackedPlayers[i];
+                        else
+                            class40_sub5_sub17_sub4_sub1 = Player.localPlayer;
+                        if (class40_sub5_sub17_sub4_sub1 != null && class40_sub5_sub17_sub4_sub1.worldX >= 0 && class40_sub5_sub17_sub4_sub1.worldX < 13312 && class40_sub5_sub17_sub4_sub1.worldY >= 0 && class40_sub5_sub17_sub4_sub1.worldY < 13312)
+                            projectile.trackTarget(pulseCycle, 0, class40_sub5_sub17_sub4_sub1.worldY, Class37.getFloorDrawHeight(projectile.anInt2981, class40_sub5_sub17_sub4_sub1.worldX, class40_sub5_sub17_sub4_sub1.worldY) - projectile.endHeight, class40_sub5_sub17_sub4_sub1.worldX);
+                    }
+                    projectile.move(anInt199);
+                    Npc.currentScene.method134(Player.worldLevel, (int) projectile.currentX, (int) projectile.currentY, (int) projectile.currentHeight, 60, projectile, projectile.anInt3013, -1, false);
+                }
+            } else
+                projectile.unlink();
         }
     }
 

--- a/src/main/java/org/runejs/client/RSCanvas.java
+++ b/src/main/java/org/runejs/client/RSCanvas.java
@@ -34,7 +34,7 @@ public class RSCanvas extends Canvas {
     }
 
     public static void clearCaches() {
-        MovedStatics.method233(true);
+        MovedStatics.method233();
         UnderlayDefinition.clearUnderlayDefinitionCache();
         GameInterface.method640();
         GameObjectDefinition.clearGameObjectModelCache();

--- a/src/main/java/org/runejs/client/cache/def/GameObjectDefinition.java
+++ b/src/main/java/org/runejs/client/cache/def/GameObjectDefinition.java
@@ -520,7 +520,7 @@ public class GameObjectDefinition extends CachedNode implements EntityDefinition
         }
     }
 
-    public boolean method610(int arg0, int arg1) {
+    public boolean method610(int arg0) {
         if(objectTypes != null) {
             for(int i = 0; objectTypes.length > i; i++) {
                 if(objectTypes[i] == arg0) {

--- a/src/main/java/org/runejs/client/cache/media/gameInterface/GameInterface.java
+++ b/src/main/java/org/runejs/client/cache/media/gameInterface/GameInterface.java
@@ -1040,7 +1040,7 @@ public class GameInterface extends CachedNode {
                                 GameShell.method28(l);
                             }
                             if(action == ActionRowType.REMOVE_IGNORE.getId()) {
-                                MovedStatics.method838(0, l);
+                                MovedStatics.method838(l);
                             }
                         }
                     }

--- a/src/main/java/org/runejs/client/input/KeyFocusListener.java
+++ b/src/main/java/org/runejs/client/input/KeyFocusListener.java
@@ -275,10 +275,7 @@ public class KeyFocusListener implements KeyListener, FocusListener {
 
     }
 
-    public static String method956(int arg0, Buffer arg1) {
-        if (arg0 < 62) {
-            aLinkedList_1278 = null;
-        }
+    public static String method956(Buffer arg1) {
         return MovedStatics.method307(arg1, -1, 32767);
     }
 

--- a/src/main/java/org/runejs/client/media/renderable/actor/Actor.java
+++ b/src/main/java/org/runejs/client/media/renderable/actor/Actor.java
@@ -272,7 +272,7 @@ public abstract class Actor extends Renderable {
                 MovedStatics.onBuildTimePlane = 0;
             Class17.regionY = chunkY;
             MovedStatics.processGameStatus(25);
-            Class51.method940(0, English.loadingPleaseWait, false, null);
+            Class51.method940(English.loadingPleaseWait, false, null);
             int i = Class26.baseY;
             int i_33_ = MovedStatics.baseX;
             MovedStatics.baseX = (chunkX - 6) * 8;

--- a/src/main/java/org/runejs/client/media/renderable/actor/Player.java
+++ b/src/main/java/org/runejs/client/media/renderable/actor/Player.java
@@ -177,7 +177,7 @@ public class Player extends Actor {
                     chatBuffer.currentPosition = 0;
                     IncomingPackets.incomingPacketBuffer.getBytes(0, messageLength, chatBuffer.buffer);
                     chatBuffer.currentPosition = 0;
-                    String incomming = KeyFocusListener.method956(124, IncomingPackets.incomingPacketBuffer);
+                    String incomming = KeyFocusListener.method956(IncomingPackets.incomingPacketBuffer);
                     String class1 = RSString.formatChatString(incomming);
                     player.forcedChatMessage = class1.trim();
                     player.anInt3078 = 150;

--- a/src/main/java/org/runejs/client/net/ISAAC.java
+++ b/src/main/java/org/runejs/client/net/ISAAC.java
@@ -215,7 +215,7 @@ public class ISAAC {
                                     }
                                     int rgb = 0;
                                     if(overlayMinimapColour != -2)
-                                        rgb = Rasterizer3D.hsl2rgb[MovedStatics.mixLightnessSigned(overlayMinimapColour, 96, true)];
+                                        rgb = Rasterizer3D.hsl2rgb[MovedStatics.mixLightnessSigned(overlayMinimapColour, 96)];
                                     if(overlayDefinition.secondaryColor != -1) {
                                         int i_54_ = 0xff & Class40_Sub5_Sub15.randomiserHue + overlayDefinition.otherHue;
                                         int i_55_ = overlayDefinition.otherSaturation + Actor.randomiserLightness;
@@ -225,9 +225,9 @@ public class ISAAC {
                                         } else
                                             i_55_ = 0;
                                         overlayMinimapColour = Class13.generateHslBitset(overlayDefinition.otherLightness, i_55_, i_54_);
-                                        rgb = Rasterizer3D.hsl2rgb[MovedStatics.mixLightnessSigned(overlayMinimapColour, 96, true)];
+                                        rgb = Rasterizer3D.hsl2rgb[MovedStatics.mixLightnessSigned(overlayMinimapColour, 96)];
                                     }
-                                    scene.addTile(_plane, x, y, shape, rotation, textureId, vertexHeightSW, vertexHeightSE, vertexHeightNE, vertexHeightNW, Class40_Sub5_Sub17_Sub6.mixLightness(hslBitsetOriginal, lightIntensitySW, (byte) 73), Class40_Sub5_Sub17_Sub6.mixLightness(hslBitsetOriginal, lightIntensitySE, (byte) 73), Class40_Sub5_Sub17_Sub6.mixLightness(hslBitsetOriginal, lightIntensityNE, (byte) 73), Class40_Sub5_Sub17_Sub6.mixLightness(hslBitsetOriginal, lightIntensityNW, (byte) 73), MovedStatics.mixLightnessSigned(hslBitset, lightIntensitySW, true), MovedStatics.mixLightnessSigned(hslBitset, lightIntensitySE, true), MovedStatics.mixLightnessSigned(hslBitset, lightIntensityNE, true), MovedStatics.mixLightnessSigned(hslBitset, lightIntensityNW, true), underlayMinimapColour, rgb);
+                                    scene.addTile(_plane, x, y, shape, rotation, textureId, vertexHeightSW, vertexHeightSE, vertexHeightNE, vertexHeightNW, Class40_Sub5_Sub17_Sub6.mixLightness(hslBitsetOriginal, lightIntensitySW, (byte) 73), Class40_Sub5_Sub17_Sub6.mixLightness(hslBitsetOriginal, lightIntensitySE, (byte) 73), Class40_Sub5_Sub17_Sub6.mixLightness(hslBitsetOriginal, lightIntensityNE, (byte) 73), Class40_Sub5_Sub17_Sub6.mixLightness(hslBitsetOriginal, lightIntensityNW, (byte) 73), MovedStatics.mixLightnessSigned(hslBitset, lightIntensitySW), MovedStatics.mixLightnessSigned(hslBitset, lightIntensitySE), MovedStatics.mixLightnessSigned(hslBitset, lightIntensityNE), MovedStatics.mixLightnessSigned(hslBitset, lightIntensityNW), underlayMinimapColour, rgb);
                                 } else
                                     scene.addTile(_plane, x, y, 0, 0, -1, vertexHeightSW, vertexHeightSE, vertexHeightNE, vertexHeightNW, Class40_Sub5_Sub17_Sub6.mixLightness(hslBitsetOriginal, lightIntensitySW, (byte) 73), Class40_Sub5_Sub17_Sub6.mixLightness(hslBitsetOriginal, lightIntensitySE, (byte) 73), Class40_Sub5_Sub17_Sub6.mixLightness(hslBitsetOriginal, lightIntensityNE, (byte) 73), Class40_Sub5_Sub17_Sub6.mixLightness(hslBitsetOriginal, lightIntensityNW, (byte) 73), 0, 0, 0, 0, underlayMinimapColour, 0);
                             }

--- a/src/main/java/org/runejs/client/net/IncomingPackets.java
+++ b/src/main/java/org/runejs/client/net/IncomingPackets.java
@@ -91,7 +91,7 @@ public class IncomingPackets {
 
             if(opcode == 71) {
                 long username = incomingPacketBuffer.getLongBE();
-                String message = RSString.formatChatString(KeyFocusListener.method956(82, incomingPacketBuffer));
+                String message = RSString.formatChatString(KeyFocusListener.method956(incomingPacketBuffer));
 
                 ChatBox.addChatMessage(Player.longToUsername(username).method85().toString(), message, 6);
                 opcode = -1;
@@ -981,7 +981,7 @@ public class IncomingPackets {
                 if(!hideMessage && !Player.inTutorialIsland) {
                     Player.privateMessageIds[Player.privateMessageIndex] = chatId;
                     Player.privateMessageIndex = (1 + Player.privateMessageIndex) % 100;
-                    String privateMessage = RSString.formatChatString(KeyFocusListener.method956(67, incomingPacketBuffer));
+                    String privateMessage = RSString.formatChatString(KeyFocusListener.method956(incomingPacketBuffer));
                     if(fromPlayerRights == 2 || fromPlayerRights == 3)
                         ChatBox.addChatMessage(Native.goldCrown + TextUtils.formatName(TextUtils.longToName(fromPlayerIndex)), privateMessage, 7);
                     else if(fromPlayerRights == 1)

--- a/src/main/java/org/runejs/client/scene/tile/GenericTile.java
+++ b/src/main/java/org/runejs/client/scene/tile/GenericTile.java
@@ -91,7 +91,7 @@ public class GenericTile {
         if(!ImageRGB.spriteExists(arg3, arg1, arg2))
             return null;
         int i = -59 % ((-60 - arg0) / 34);
-        return MovedStatics.method319((byte) -62);
+        return MovedStatics.method319();
     }
 
     public static void method945(int arg0, int arg1, int arg2, int arg3, int arg4, int arg5, int arg6, int arg7) {


### PR DESCRIPTION
I removed a load of dummy arguments, generally these functions only had 1 call site so it was very easy to identify the dummys and remove them.

A couple of the methods had 2 or 3 call sites but it was easy enough to inspect them and figure out the logic.

--- client tested as working 😄