### PR TITLE
feat: create `VariableLengthPacketBuffer` to handle variable lengths

### DIFF
--- a/src/main/java/org/runejs/client/Main.java
+++ b/src/main/java/org/runejs/client/Main.java
@@ -1736,6 +1736,10 @@ public class Main extends GameShell {
                 MovedStatics.packetBuffer.putBytes(0, SceneCluster.packetBuffer.currentPosition, SceneCluster.packetBuffer.buffer);
                 MovedStatics.gameServerSocket.sendDataFromBuffer(MovedStatics.packetBuffer.currentPosition, 0, MovedStatics.packetBuffer.buffer);
                 SceneCluster.packetBuffer.initOutCipher(seeds);
+
+                // TODO (Jameskmonger) this allows the OutgoingPackets to access the ISAAC cipher. This is a hack and should be fixed.
+                OutgoingPackets.init(SceneCluster.packetBuffer.outCipher);
+                
                 for (int i = 0; i < 4; i++) {
                     seeds[i] += 50;
                 }

--- a/src/main/java/org/runejs/client/ProducingGraphicsBuffer_Sub1.java
+++ b/src/main/java/org/runejs/client/ProducingGraphicsBuffer_Sub1.java
@@ -63,12 +63,12 @@ public class ProducingGraphicsBuffer_Sub1 extends ProducingGraphicsBuffer implem
         return false;
     }
 
-    public static int method1052(String arg1, Buffer arg2) {
-        int i = arg2.currentPosition;
-        byte[] strBytes = arg1.getBytes(StandardCharsets.UTF_8);
-        arg2.putSmart(strBytes.length);
-        arg2.currentPosition += IdentityKit.aHuffmanEncoding_2590.encrypt(0, arg2.currentPosition, strBytes.length, strBytes, arg2.buffer);
-        return -i + arg2.currentPosition;
+    public static int method1052(String value, Buffer buffer) {
+        int startingPosition = buffer.currentPosition;
+        byte[] strBytes = value.getBytes(StandardCharsets.UTF_8);
+        buffer.putSmart(strBytes.length);
+        buffer.currentPosition += IdentityKit.aHuffmanEncoding_2590.encrypt(0, buffer.currentPosition, strBytes.length, strBytes, buffer.buffer);
+        return buffer.currentPosition - startingPosition;
 
     }
 

--- a/src/main/java/org/runejs/client/io/Buffer.java
+++ b/src/main/java/org/runejs/client/io/Buffer.java
@@ -160,8 +160,13 @@ public class Buffer extends Node {
         buffer[currentPosition++] = (byte) value;
     }
 
-    public void finishVarByte(int value) {
-        buffer[-1 + currentPosition + -value] = (byte) value;
+    /**
+     * Updates the length marker byte for a variable length packet.
+     * 
+     * @param length The length of the packet.
+     */
+    public void finishVarByte(int length) {
+        buffer[-1 + currentPosition - length] = (byte) length;
     }
 
     public void putLongBE(long arg0) {

--- a/src/main/java/org/runejs/client/net/OutgoingPackets.java
+++ b/src/main/java/org/runejs/client/net/OutgoingPackets.java
@@ -27,7 +27,19 @@ public class OutgoingPackets {
         return buffer;
     }
 
-    // TODO (Jameskmonger) add support for variable-length packets
+    /**
+     * Opens a variable-length packet with the specified opcode.
+     * 
+     * The first byte of the packet will be reserved for the size of the packet.
+     */
+    public static VariableLengthPacketBuffer openVariableSizePacket(int opcode) {
+        VariableLengthPacketBuffer buffer = new VariableLengthPacketBuffer();
+        
+        buffer.outCipher = outCipher;
+        buffer.putPacket(opcode);
+
+        return buffer;
+    }
 
     /**
      * Sends an OutboundMessage to the server.
@@ -42,7 +54,6 @@ public class OutgoingPackets {
         PacketBuffer buffer = encoder.encode(message);
 
         // TODO (Jameskmonger) this shouldn't live on SceneCluster
-        int initialPosition = SceneCluster.packetBuffer.currentPosition;
-        SceneCluster.packetBuffer.putBytes(0, buffer.size, buffer.buffer);
+        SceneCluster.packetBuffer.putBytes(0, buffer.getSize(), buffer.buffer);
     }
 }

--- a/src/main/java/org/runejs/client/net/PacketBuffer.java
+++ b/src/main/java/org/runejs/client/net/PacketBuffer.java
@@ -24,7 +24,7 @@ public class PacketBuffer extends Buffer {
     /**
      * The size of this packet buffer, in bytes.
      */
-    public final int size;
+    private final int size;
 
     /**
      * Creates a new packet buffer with the specified size, in bytes.
@@ -33,6 +33,13 @@ public class PacketBuffer extends Buffer {
         super(size);
 
         this.size = size;
+    }
+
+    /**
+     * Gets the size of this packet buffer, in bytes.
+     */
+    public int getSize() {
+        return this.size;
     }
 
     public static void method513(int arg0, CacheArchive arg1, CacheIndex arg2, byte arg3) {
@@ -152,6 +159,7 @@ public class PacketBuffer extends Buffer {
     }
 
     public void putPacket(int packetId) {
+        //System.out.println("putPacket: " + packetId);
         buffer[currentPosition++] = (byte) (packetId + outCipher.nextInt() & 0xff);
     }
 

--- a/src/main/java/org/runejs/client/net/VariableLengthPacketBuffer.java
+++ b/src/main/java/org/runejs/client/net/VariableLengthPacketBuffer.java
@@ -1,0 +1,89 @@
+package org.runejs.client.net;
+
+/**
+ * A packet buffer that can be used to write variable-length packets.
+ * 
+ * This is used for packets that have a variable size, such as the
+ * chat message packet.
+ * 
+ * The size of the packet is written to the reserved size marker byte
+ * when the packet is closed. This byte is stored at index 1 in the
+ * buffer.
+ */
+public class VariableLengthPacketBuffer extends PacketBuffer {
+    /**
+     * The maximum size of a packet.
+     * 
+     * This is set to 255 because that's the maximum size that can
+     * be encoded in a single byte.
+     */
+    private static int MAX_PACKET_SIZE = 255;
+
+    /**
+     * Whether the opcode and reserved size marker byte have been written yet.
+     */
+    private boolean isOpcodeWritten = false;
+
+    /**
+     * Whether the reserved size marker byte has been populated.
+     */
+    private boolean isSizeWritten = false;
+
+    public VariableLengthPacketBuffer() {
+        // the packet size plus the opcode and reserved size marker byte
+        super(MAX_PACKET_SIZE + 2);
+    }
+
+    /**
+     * Gets the size of the packet based on the value written to the length marker byte.
+     */
+    @Override
+    public int getSize() {
+        if (!isSizeWritten) {
+            throw new IllegalStateException("Size has not been written");
+        }
+
+        // the packet size plus the opcode and reserved size marker byte
+        return buffer[1] + 2;
+    }
+
+    /**
+     * Opens a packet and reserves a byte for the size of the packet.
+     */
+    public void putPacket(int opcode) {
+        if (isOpcodeWritten) {
+            throw new IllegalStateException("Opcode has already been written");
+        }
+
+        super.putPacket(opcode);
+
+        // this is the size of the packet, which we don't know yet
+        super.putByte(0);
+
+        isOpcodeWritten = true;
+    }
+
+    /**
+     * Writes the size of the packet to the reserved size marker byte.
+     */
+    public void writePacketLength() {
+        if (!isOpcodeWritten) {
+            throw new IllegalStateException("Opcode has not been written");
+        }
+
+        if (isSizeWritten) {
+            throw new IllegalStateException("Size has already been written");
+        }
+
+        // the size of the packet is the current position minus the opcode and reserved size marker byte
+        int size = currentPosition - 2;
+        if (size > MAX_PACKET_SIZE) {
+            throw new IllegalStateException("Packet size is too large");
+        }
+
+        // write the size of the packet
+        buffer[1] = (byte) size;
+
+        isSizeWritten = true;
+    }
+}


### PR DESCRIPTION
Allows us to create a variable length packet where the length fits in a byte (type `-1`)

We can expand this in future if needed for variable length `-2` (length fits in a short), but I'm not sure if the client needs that functionality.