### PR TITLE
fix: fix parameter order for chat effects

### DIFF
--- a/src/main/java/org/runejs/client/Class33.java
+++ b/src/main/java/org/runejs/client/Class33.java
@@ -181,16 +181,16 @@ public class Class33 {
                     TypeFace.fontBold.drawStringLeft(class1, ISAAC.anInt522, Class44.anInt1048, i_8_);
                 }
                 if(PlayerAppearance.anIntArray695[i] == 1) {
-                    TypeFace.fontBold.drawCenteredStringWaveY(class1, ISAAC.anInt522, Class44.anInt1048 + 1, 0, MovedStatics.anInt2628);
-                    TypeFace.fontBold.drawCenteredStringWaveY(class1, ISAAC.anInt522, Class44.anInt1048, i_8_, MovedStatics.anInt2628);
+                    TypeFace.fontBold.drawCenteredStringWaveY(class1, ISAAC.anInt522, Class44.anInt1048 + 1, MovedStatics.anInt2628, 0);
+                    TypeFace.fontBold.drawCenteredStringWaveY(class1, ISAAC.anInt522, Class44.anInt1048, MovedStatics.anInt2628, i_8_);
                 }
                 if(PlayerAppearance.anIntArray695[i] == 2) {
-                    TypeFace.fontBold.drawCenteredStringWaveXY(class1, ISAAC.anInt522, 1 + Class44.anInt1048, 0, MovedStatics.anInt2628);
-                    TypeFace.fontBold.drawCenteredStringWaveXY(class1, ISAAC.anInt522, Class44.anInt1048, i_8_, MovedStatics.anInt2628);
+                    TypeFace.fontBold.drawCenteredStringWaveXY(class1, ISAAC.anInt522, 1 + Class44.anInt1048, MovedStatics.anInt2628, 0);
+                    TypeFace.fontBold.drawCenteredStringWaveXY(class1, ISAAC.anInt522, Class44.anInt1048, MovedStatics.anInt2628, i_8_);
                 }
                 if(PlayerAppearance.anIntArray695[i] == 3) {
-                    TypeFace.fontBold.drawCenteredStringWaveXYMove(class1, ISAAC.anInt522, Class44.anInt1048 + 1, 0, MovedStatics.anInt2628, -PlayerAppearance.anIntArray684[i] + 150);
-                    TypeFace.fontBold.drawCenteredStringWaveXYMove(class1, ISAAC.anInt522, Class44.anInt1048, i_8_, MovedStatics.anInt2628, -PlayerAppearance.anIntArray684[i] + 150);
+                    TypeFace.fontBold.drawCenteredStringWaveXYMove(class1, ISAAC.anInt522, Class44.anInt1048 + 1, MovedStatics.anInt2628, -PlayerAppearance.anIntArray684[i] + 150, 0);
+                    TypeFace.fontBold.drawCenteredStringWaveXYMove(class1, ISAAC.anInt522, Class44.anInt1048, MovedStatics.anInt2628, -PlayerAppearance.anIntArray684[i] + 150, i_8_);
                 }
                 if(PlayerAppearance.anIntArray695[i] == 4) {
                     int i_12_ = TypeFace.fontBold.getStringWidth(class1);


### PR DESCRIPTION
the text colours of chat effects was broken, and the waves weren't working properly

will do another refactor of this area as there's a lot of quick wins around this chat code 

![image](https://github.com/runejs/refactored-client-435/assets/2037007/75e2e780-a553-4b26-af2a-4a85f64a2b2c)


I think it came from some changes made in this PR https://github.com/runejs/refactored-client-435/pull/17/