### PR TITLE
refactor: renaming around chat color/shape rendering, use new enums too

### DIFF
--- a/src/main/java/org/runejs/client/Class33.java
+++ b/src/main/java/org/runejs/client/Class33.java
@@ -3,6 +3,8 @@ package org.runejs.client;
 import org.runejs.client.cache.def.ActorDefinition;
 import org.runejs.client.cache.media.AnimationSequence;
 import org.runejs.client.cache.media.TypeFace;
+import org.runejs.client.chat.ChatColorEffect;
+import org.runejs.client.chat.ChatShapeEffect;
 import org.runejs.client.frame.ChatBox;
 import org.runejs.client.language.Native;
 import org.runejs.client.media.Rasterizer;
@@ -137,15 +139,17 @@ public class Class33 {
             String message = PlayerAppearance.overheadChatMessage[i];
             if(MovedStatics.chatEffectsDisabled == 0) {
                 int textColor = MovedStatics.OVERHEAD_CHAT_COLORS[0];
+                // standard 6 colors (yellow, red, green, cyan, purple, white)
+                // TODO (James) tie this into the ChatColorEffect enum
                 if(PlayerAppearance.overheadChatColor[i] < 6)
                     textColor = MovedStatics.OVERHEAD_CHAT_COLORS[PlayerAppearance.overheadChatColor[i]];
-                if(PlayerAppearance.overheadChatColor[i] == 6)
+                if(PlayerAppearance.overheadChatColor[i] == ChatColorEffect.FLASH1.getNetworkCode())
                     textColor = MovedStatics.anInt2628 % 20 >= 10 ? MovedStatics.OVERHEAD_CHAT_COLORS[0] : MovedStatics.OVERHEAD_CHAT_COLORS[1];
-                if(PlayerAppearance.overheadChatColor[i] == 7)
+                if(PlayerAppearance.overheadChatColor[i] == ChatColorEffect.FLASH2.getNetworkCode())
                     textColor = MovedStatics.anInt2628 % 20 < 10 ? 255 : MovedStatics.OVERHEAD_CHAT_COLORS[3];
-                if(PlayerAppearance.overheadChatColor[i] == 8)
+                if(PlayerAppearance.overheadChatColor[i] == ChatColorEffect.FLASH3.getNetworkCode())
                     textColor = MovedStatics.anInt2628 % 20 >= 10 ? 8454016 : 45056;
-                if(PlayerAppearance.overheadChatColor[i] == 9) {
+                if(PlayerAppearance.overheadChatColor[i] == ChatColorEffect.GLOW1.getNetworkCode()) {
                     int i_9_ = 150 - PlayerAppearance.anIntArray684[i];
                     if(i_9_ >= 50) {
                         if(i_9_ < 100)
@@ -155,7 +159,7 @@ public class Class33 {
                     } else
                         textColor = MovedStatics.OVERHEAD_CHAT_COLORS[1] + 1280 * i_9_;
                 }
-                if(PlayerAppearance.overheadChatColor[i] == 10) {
+                if(PlayerAppearance.overheadChatColor[i] == ChatColorEffect.GLOW2.getNetworkCode()) {
                     int i_10_ = 150 + -PlayerAppearance.anIntArray684[i];
                     if(i_10_ >= 50) {
                         if(i_10_ >= 100) {
@@ -166,7 +170,7 @@ public class Class33 {
                     } else
                         textColor = 5 * i_10_ + MovedStatics.OVERHEAD_CHAT_COLORS[1];
                 }
-                if(PlayerAppearance.overheadChatColor[i] == 11) {
+                if(PlayerAppearance.overheadChatColor[i] == ChatColorEffect.GLOW3.getNetworkCode()) {
                     int i_11_ = -PlayerAppearance.anIntArray684[i] + 150;
                     if(i_11_ >= 50) {
                         if(i_11_ < 100)
@@ -176,23 +180,23 @@ public class Class33 {
                     } else
                         textColor = -(327685 * i_11_) + MovedStatics.OVERHEAD_CHAT_COLORS[5];
                 }
-                if(PlayerAppearance.overheadChatEffect[i] == 0) {
+                if(PlayerAppearance.overheadChatEffect[i] == ChatShapeEffect.NONE.getNetworkCode()) {
                     TypeFace.fontBold.drawStringLeft(message, ISAAC.anInt522, Class44.anInt1048 + 1, 0);
                     TypeFace.fontBold.drawStringLeft(message, ISAAC.anInt522, Class44.anInt1048, textColor);
                 }
-                if(PlayerAppearance.overheadChatEffect[i] == 1) {
+                if(PlayerAppearance.overheadChatEffect[i] == ChatShapeEffect.WAVE.getNetworkCode()) {
                     TypeFace.fontBold.drawCenteredStringWaveY(message, ISAAC.anInt522, Class44.anInt1048 + 1, 0, MovedStatics.anInt2628);
                     TypeFace.fontBold.drawCenteredStringWaveY(message, ISAAC.anInt522, Class44.anInt1048, textColor, MovedStatics.anInt2628);
                 }
-                if(PlayerAppearance.overheadChatEffect[i] == 2) {
+                if(PlayerAppearance.overheadChatEffect[i] == ChatShapeEffect.WAVE2.getNetworkCode()) {
                     TypeFace.fontBold.drawCenteredStringWaveXY(message, ISAAC.anInt522, 1 + Class44.anInt1048, 0, MovedStatics.anInt2628);
                     TypeFace.fontBold.drawCenteredStringWaveXY(message, ISAAC.anInt522, Class44.anInt1048, textColor, MovedStatics.anInt2628);
                 }
-                if(PlayerAppearance.overheadChatEffect[i] == 3) {
+                if(PlayerAppearance.overheadChatEffect[i] == ChatShapeEffect.SHAKE.getNetworkCode()) {
                     TypeFace.fontBold.drawCenteredStringWaveXYMove(message, ISAAC.anInt522, Class44.anInt1048 + 1, 0, MovedStatics.anInt2628, -PlayerAppearance.anIntArray684[i] + 150);
                     TypeFace.fontBold.drawCenteredStringWaveXYMove(message, ISAAC.anInt522, Class44.anInt1048, textColor, MovedStatics.anInt2628, -PlayerAppearance.anIntArray684[i] + 150);
                 }
-                if(PlayerAppearance.overheadChatEffect[i] == 4) {
+                if(PlayerAppearance.overheadChatEffect[i] == ChatShapeEffect.SCROLL.getNetworkCode()) {
                     int i_12_ = TypeFace.fontBold.getStringWidth(message);
                     int i_13_ = (i_12_ + 100) * (150 + -PlayerAppearance.anIntArray684[i]) / 150;
                     Rasterizer.setBounds(ISAAC.anInt522 + -50, 0, 50 + ISAAC.anInt522, 334);
@@ -200,7 +204,7 @@ public class Class33 {
                     TypeFace.fontBold.drawString(message, 50 + ISAAC.anInt522 + -i_13_, Class44.anInt1048, textColor);
                     Rasterizer.resetBounds();
                 }
-                if(PlayerAppearance.overheadChatEffect[i] == 5) {
+                if(PlayerAppearance.overheadChatEffect[i] == ChatShapeEffect.SLIDE.getNetworkCode()) {
                     int i_14_ = 0;
                     int i_15_ = 150 + -PlayerAppearance.anIntArray684[i];
                     Rasterizer.setBounds(0, -1 + -TypeFace.fontBold.characterDefaultHeight + Class44.anInt1048, 512, 5 + Class44.anInt1048);

--- a/src/main/java/org/runejs/client/Class33.java
+++ b/src/main/java/org/runejs/client/Class33.java
@@ -81,7 +81,7 @@ public class Class33 {
                         PlayerAppearance.anIntArray715[SceneCluster.anInt770] = ISAAC.anInt522;
                         PlayerAppearance.anIntArray685[SceneCluster.anInt770] = Class44.anInt1048;
                         PlayerAppearance.overheadChatColor[SceneCluster.anInt770] = actor.chatcolor;
-                        PlayerAppearance.overheadChatEffect[SceneCluster.anInt770] = actor.chatEffects;
+                        PlayerAppearance.overheadChatShape[SceneCluster.anInt770] = actor.chatEffects;
                         PlayerAppearance.anIntArray684[SceneCluster.anInt770] = actor.anInt3078;
                         PlayerAppearance.overheadChatMessage[SceneCluster.anInt770] = actor.forcedChatMessage;
                         SceneCluster.anInt770++;
@@ -180,23 +180,23 @@ public class Class33 {
                     } else
                         textColor = -(327685 * i_11_) + MovedStatics.OVERHEAD_CHAT_COLORS[5];
                 }
-                if(PlayerAppearance.overheadChatEffect[i] == ChatShapeEffect.NONE.getNetworkCode()) {
+                if(PlayerAppearance.overheadChatShape[i] == ChatShapeEffect.NONE.getNetworkCode()) {
                     TypeFace.fontBold.drawStringLeft(message, ISAAC.anInt522, Class44.anInt1048 + 1, 0);
                     TypeFace.fontBold.drawStringLeft(message, ISAAC.anInt522, Class44.anInt1048, textColor);
                 }
-                if(PlayerAppearance.overheadChatEffect[i] == ChatShapeEffect.WAVE.getNetworkCode()) {
+                if(PlayerAppearance.overheadChatShape[i] == ChatShapeEffect.WAVE.getNetworkCode()) {
                     TypeFace.fontBold.drawCenteredStringWaveY(message, ISAAC.anInt522, Class44.anInt1048 + 1, 0, MovedStatics.anInt2628);
                     TypeFace.fontBold.drawCenteredStringWaveY(message, ISAAC.anInt522, Class44.anInt1048, textColor, MovedStatics.anInt2628);
                 }
-                if(PlayerAppearance.overheadChatEffect[i] == ChatShapeEffect.WAVE2.getNetworkCode()) {
+                if(PlayerAppearance.overheadChatShape[i] == ChatShapeEffect.WAVE2.getNetworkCode()) {
                     TypeFace.fontBold.drawCenteredStringWaveXY(message, ISAAC.anInt522, 1 + Class44.anInt1048, 0, MovedStatics.anInt2628);
                     TypeFace.fontBold.drawCenteredStringWaveXY(message, ISAAC.anInt522, Class44.anInt1048, textColor, MovedStatics.anInt2628);
                 }
-                if(PlayerAppearance.overheadChatEffect[i] == ChatShapeEffect.SHAKE.getNetworkCode()) {
+                if(PlayerAppearance.overheadChatShape[i] == ChatShapeEffect.SHAKE.getNetworkCode()) {
                     TypeFace.fontBold.drawCenteredStringWaveXYMove(message, ISAAC.anInt522, Class44.anInt1048 + 1, 0, MovedStatics.anInt2628, -PlayerAppearance.anIntArray684[i] + 150);
                     TypeFace.fontBold.drawCenteredStringWaveXYMove(message, ISAAC.anInt522, Class44.anInt1048, textColor, MovedStatics.anInt2628, -PlayerAppearance.anIntArray684[i] + 150);
                 }
-                if(PlayerAppearance.overheadChatEffect[i] == ChatShapeEffect.SCROLL.getNetworkCode()) {
+                if(PlayerAppearance.overheadChatShape[i] == ChatShapeEffect.SCROLL.getNetworkCode()) {
                     int i_12_ = TypeFace.fontBold.getStringWidth(message);
                     int i_13_ = (i_12_ + 100) * (150 + -PlayerAppearance.anIntArray684[i]) / 150;
                     Rasterizer.setBounds(ISAAC.anInt522 + -50, 0, 50 + ISAAC.anInt522, 334);
@@ -204,7 +204,7 @@ public class Class33 {
                     TypeFace.fontBold.drawString(message, 50 + ISAAC.anInt522 + -i_13_, Class44.anInt1048, textColor);
                     Rasterizer.resetBounds();
                 }
-                if(PlayerAppearance.overheadChatEffect[i] == ChatShapeEffect.SLIDE.getNetworkCode()) {
+                if(PlayerAppearance.overheadChatShape[i] == ChatShapeEffect.SLIDE.getNetworkCode()) {
                     int i_14_ = 0;
                     int i_15_ = 150 + -PlayerAppearance.anIntArray684[i];
                     Rasterizer.setBounds(0, -1 + -TypeFace.fontBold.characterDefaultHeight + Class44.anInt1048, 512, 5 + Class44.anInt1048);

--- a/src/main/java/org/runejs/client/Class33.java
+++ b/src/main/java/org/runejs/client/Class33.java
@@ -78,10 +78,10 @@ public class Class33 {
                         PlayerAppearance.anIntArray688[SceneCluster.anInt770] = TypeFace.fontBold.characterDefaultHeight;
                         PlayerAppearance.anIntArray715[SceneCluster.anInt770] = ISAAC.anInt522;
                         PlayerAppearance.anIntArray685[SceneCluster.anInt770] = Class44.anInt1048;
-                        PlayerAppearance.anIntArray712[SceneCluster.anInt770] = actor.chatcolor;
-                        PlayerAppearance.anIntArray695[SceneCluster.anInt770] = actor.chatEffects;
+                        PlayerAppearance.overheadChatColor[SceneCluster.anInt770] = actor.chatcolor;
+                        PlayerAppearance.overheadChatEffect[SceneCluster.anInt770] = actor.chatEffects;
                         PlayerAppearance.anIntArray684[SceneCluster.anInt770] = actor.anInt3078;
-                        PlayerAppearance.aClass1Array697[SceneCluster.anInt770] = actor.forcedChatMessage;
+                        PlayerAppearance.overheadChatMessage[SceneCluster.anInt770] = actor.forcedChatMessage;
                         SceneCluster.anInt770++;
                     }
                 }
@@ -134,18 +134,18 @@ public class Class33 {
             }
             ISAAC.anInt522 = PlayerAppearance.anIntArray715[i];
             Class44.anInt1048 = PlayerAppearance.anIntArray685[i] = i_4_;
-            String class1 = PlayerAppearance.aClass1Array697[i];
+            String class1 = PlayerAppearance.overheadChatMessage[i];
             if(MovedStatics.anInt2280 == 0) {
                 int i_8_ = 16776960;
-                if(PlayerAppearance.anIntArray712[i] < 6)
-                    i_8_ = MovedStatics.anIntArray2106[PlayerAppearance.anIntArray712[i]];
-                if(PlayerAppearance.anIntArray712[i] == 6)
+                if(PlayerAppearance.overheadChatColor[i] < 6)
+                    i_8_ = MovedStatics.anIntArray2106[PlayerAppearance.overheadChatColor[i]];
+                if(PlayerAppearance.overheadChatColor[i] == 6)
                     i_8_ = MovedStatics.anInt2628 % 20 >= 10 ? 16776960 : 16711680;
-                if(PlayerAppearance.anIntArray712[i] == 7)
+                if(PlayerAppearance.overheadChatColor[i] == 7)
                     i_8_ = MovedStatics.anInt2628 % 20 < 10 ? 255 : 65535;
-                if(PlayerAppearance.anIntArray712[i] == 8)
+                if(PlayerAppearance.overheadChatColor[i] == 8)
                     i_8_ = MovedStatics.anInt2628 % 20 >= 10 ? 8454016 : 45056;
-                if(PlayerAppearance.anIntArray712[i] == 9) {
+                if(PlayerAppearance.overheadChatColor[i] == 9) {
                     int i_9_ = 150 - PlayerAppearance.anIntArray684[i];
                     if(i_9_ >= 50) {
                         if(i_9_ < 100)
@@ -155,7 +155,7 @@ public class Class33 {
                     } else
                         i_8_ = 16711680 + 1280 * i_9_;
                 }
-                if(PlayerAppearance.anIntArray712[i] == 10) {
+                if(PlayerAppearance.overheadChatColor[i] == 10) {
                     int i_10_ = 150 + -PlayerAppearance.anIntArray684[i];
                     if(i_10_ >= 50) {
                         if(i_10_ >= 100) {
@@ -166,7 +166,7 @@ public class Class33 {
                     } else
                         i_8_ = 5 * i_10_ + 16711680;
                 }
-                if(PlayerAppearance.anIntArray712[i] == 11) {
+                if(PlayerAppearance.overheadChatColor[i] == 11) {
                     int i_11_ = -PlayerAppearance.anIntArray684[i] + 150;
                     if(i_11_ >= 50) {
                         if(i_11_ < 100)
@@ -176,23 +176,23 @@ public class Class33 {
                     } else
                         i_8_ = -(327685 * i_11_) + 16777215;
                 }
-                if(PlayerAppearance.anIntArray695[i] == 0) {
+                if(PlayerAppearance.overheadChatEffect[i] == 0) {
                     TypeFace.fontBold.drawStringLeft(class1, ISAAC.anInt522, Class44.anInt1048 + 1, 0);
                     TypeFace.fontBold.drawStringLeft(class1, ISAAC.anInt522, Class44.anInt1048, i_8_);
                 }
-                if(PlayerAppearance.anIntArray695[i] == 1) {
+                if(PlayerAppearance.overheadChatEffect[i] == 1) {
                     TypeFace.fontBold.drawCenteredStringWaveY(class1, ISAAC.anInt522, Class44.anInt1048 + 1, 0, MovedStatics.anInt2628);
                     TypeFace.fontBold.drawCenteredStringWaveY(class1, ISAAC.anInt522, Class44.anInt1048, i_8_, MovedStatics.anInt2628);
                 }
-                if(PlayerAppearance.anIntArray695[i] == 2) {
+                if(PlayerAppearance.overheadChatEffect[i] == 2) {
                     TypeFace.fontBold.drawCenteredStringWaveXY(class1, ISAAC.anInt522, 1 + Class44.anInt1048, 0, MovedStatics.anInt2628);
                     TypeFace.fontBold.drawCenteredStringWaveXY(class1, ISAAC.anInt522, Class44.anInt1048, i_8_, MovedStatics.anInt2628);
                 }
-                if(PlayerAppearance.anIntArray695[i] == 3) {
+                if(PlayerAppearance.overheadChatEffect[i] == 3) {
                     TypeFace.fontBold.drawCenteredStringWaveXYMove(class1, ISAAC.anInt522, Class44.anInt1048 + 1, 0, MovedStatics.anInt2628, -PlayerAppearance.anIntArray684[i] + 150);
                     TypeFace.fontBold.drawCenteredStringWaveXYMove(class1, ISAAC.anInt522, Class44.anInt1048, i_8_, MovedStatics.anInt2628, -PlayerAppearance.anIntArray684[i] + 150);
                 }
-                if(PlayerAppearance.anIntArray695[i] == 4) {
+                if(PlayerAppearance.overheadChatEffect[i] == 4) {
                     int i_12_ = TypeFace.fontBold.getStringWidth(class1);
                     int i_13_ = (i_12_ + 100) * (150 + -PlayerAppearance.anIntArray684[i]) / 150;
                     Rasterizer.setBounds(ISAAC.anInt522 + -50, 0, 50 + ISAAC.anInt522, 334);
@@ -200,7 +200,7 @@ public class Class33 {
                     TypeFace.fontBold.drawString(class1, 50 + ISAAC.anInt522 + -i_13_, Class44.anInt1048, i_8_);
                     Rasterizer.resetBounds();
                 }
-                if(PlayerAppearance.anIntArray695[i] == 5) {
+                if(PlayerAppearance.overheadChatEffect[i] == 5) {
                     int i_14_ = 0;
                     int i_15_ = 150 + -PlayerAppearance.anIntArray684[i];
                     Rasterizer.setBounds(0, -1 + -TypeFace.fontBold.characterDefaultHeight + Class44.anInt1048, 512, 5 + Class44.anInt1048);

--- a/src/main/java/org/runejs/client/Class33.java
+++ b/src/main/java/org/runejs/client/Class33.java
@@ -134,70 +134,70 @@ public class Class33 {
             }
             ISAAC.anInt522 = PlayerAppearance.anIntArray715[i];
             Class44.anInt1048 = PlayerAppearance.anIntArray685[i] = i_4_;
-            String class1 = PlayerAppearance.overheadChatMessage[i];
+            String message = PlayerAppearance.overheadChatMessage[i];
             if(MovedStatics.chatEffectsDisabled == 0) {
-                int i_8_ = MovedStatics.OVERHEAD_CHAT_COLORS[0];
+                int textColor = MovedStatics.OVERHEAD_CHAT_COLORS[0];
                 if(PlayerAppearance.overheadChatColor[i] < 6)
-                    i_8_ = MovedStatics.OVERHEAD_CHAT_COLORS[PlayerAppearance.overheadChatColor[i]];
+                    textColor = MovedStatics.OVERHEAD_CHAT_COLORS[PlayerAppearance.overheadChatColor[i]];
                 if(PlayerAppearance.overheadChatColor[i] == 6)
-                    i_8_ = MovedStatics.anInt2628 % 20 >= 10 ? 16776960 : 16711680;
+                    textColor = MovedStatics.anInt2628 % 20 >= 10 ? 16776960 : 16711680;
                 if(PlayerAppearance.overheadChatColor[i] == 7)
-                    i_8_ = MovedStatics.anInt2628 % 20 < 10 ? 255 : 65535;
+                    textColor = MovedStatics.anInt2628 % 20 < 10 ? 255 : 65535;
                 if(PlayerAppearance.overheadChatColor[i] == 8)
-                    i_8_ = MovedStatics.anInt2628 % 20 >= 10 ? 8454016 : 45056;
+                    textColor = MovedStatics.anInt2628 % 20 >= 10 ? 8454016 : 45056;
                 if(PlayerAppearance.overheadChatColor[i] == 9) {
                     int i_9_ = 150 - PlayerAppearance.anIntArray684[i];
                     if(i_9_ >= 50) {
                         if(i_9_ < 100)
-                            i_8_ = -((-50 + i_9_) * 327680) + 16776960;
+                            textColor = -((-50 + i_9_) * 327680) + 16776960;
                         else if(i_9_ < 150)
-                            i_8_ = 65280 + 5 * (i_9_ + -100);
+                            textColor = 65280 + 5 * (i_9_ + -100);
                     } else
-                        i_8_ = 16711680 + 1280 * i_9_;
+                        textColor = 16711680 + 1280 * i_9_;
                 }
                 if(PlayerAppearance.overheadChatColor[i] == 10) {
                     int i_10_ = 150 + -PlayerAppearance.anIntArray684[i];
                     if(i_10_ >= 50) {
                         if(i_10_ >= 100) {
                             if(i_10_ < 150)
-                                i_8_ = 255 - (-(327680 * (i_10_ - 100)) - 500) + -(5 * i_10_);
+                                textColor = 255 - (-(327680 * (i_10_ - 100)) - 500) + -(5 * i_10_);
                         } else
-                            i_8_ = 16711935 - (327680 * i_10_ - 16384000);
+                            textColor = 16711935 - (327680 * i_10_ - 16384000);
                     } else
-                        i_8_ = 5 * i_10_ + 16711680;
+                        textColor = 5 * i_10_ + 16711680;
                 }
                 if(PlayerAppearance.overheadChatColor[i] == 11) {
                     int i_11_ = -PlayerAppearance.anIntArray684[i] + 150;
                     if(i_11_ >= 50) {
                         if(i_11_ < 100)
-                            i_8_ = 327685 * (i_11_ - 50) + 65280;
+                            textColor = 327685 * (i_11_ - 50) + 65280;
                         else if(i_11_ < 150)
-                            i_8_ = -((-100 + i_11_) * 327680) + 16777215;
+                            textColor = -((-100 + i_11_) * 327680) + 16777215;
                     } else
-                        i_8_ = -(327685 * i_11_) + 16777215;
+                        textColor = -(327685 * i_11_) + 16777215;
                 }
                 if(PlayerAppearance.overheadChatEffect[i] == 0) {
-                    TypeFace.fontBold.drawStringLeft(class1, ISAAC.anInt522, Class44.anInt1048 + 1, 0);
-                    TypeFace.fontBold.drawStringLeft(class1, ISAAC.anInt522, Class44.anInt1048, i_8_);
+                    TypeFace.fontBold.drawStringLeft(message, ISAAC.anInt522, Class44.anInt1048 + 1, 0);
+                    TypeFace.fontBold.drawStringLeft(message, ISAAC.anInt522, Class44.anInt1048, textColor);
                 }
                 if(PlayerAppearance.overheadChatEffect[i] == 1) {
-                    TypeFace.fontBold.drawCenteredStringWaveY(class1, ISAAC.anInt522, Class44.anInt1048 + 1, 0, MovedStatics.anInt2628);
-                    TypeFace.fontBold.drawCenteredStringWaveY(class1, ISAAC.anInt522, Class44.anInt1048, i_8_, MovedStatics.anInt2628);
+                    TypeFace.fontBold.drawCenteredStringWaveY(message, ISAAC.anInt522, Class44.anInt1048 + 1, 0, MovedStatics.anInt2628);
+                    TypeFace.fontBold.drawCenteredStringWaveY(message, ISAAC.anInt522, Class44.anInt1048, textColor, MovedStatics.anInt2628);
                 }
                 if(PlayerAppearance.overheadChatEffect[i] == 2) {
-                    TypeFace.fontBold.drawCenteredStringWaveXY(class1, ISAAC.anInt522, 1 + Class44.anInt1048, 0, MovedStatics.anInt2628);
-                    TypeFace.fontBold.drawCenteredStringWaveXY(class1, ISAAC.anInt522, Class44.anInt1048, i_8_, MovedStatics.anInt2628);
+                    TypeFace.fontBold.drawCenteredStringWaveXY(message, ISAAC.anInt522, 1 + Class44.anInt1048, 0, MovedStatics.anInt2628);
+                    TypeFace.fontBold.drawCenteredStringWaveXY(message, ISAAC.anInt522, Class44.anInt1048, textColor, MovedStatics.anInt2628);
                 }
                 if(PlayerAppearance.overheadChatEffect[i] == 3) {
-                    TypeFace.fontBold.drawCenteredStringWaveXYMove(class1, ISAAC.anInt522, Class44.anInt1048 + 1, 0, MovedStatics.anInt2628, -PlayerAppearance.anIntArray684[i] + 150);
-                    TypeFace.fontBold.drawCenteredStringWaveXYMove(class1, ISAAC.anInt522, Class44.anInt1048, i_8_, MovedStatics.anInt2628, -PlayerAppearance.anIntArray684[i] + 150);
+                    TypeFace.fontBold.drawCenteredStringWaveXYMove(message, ISAAC.anInt522, Class44.anInt1048 + 1, 0, MovedStatics.anInt2628, -PlayerAppearance.anIntArray684[i] + 150);
+                    TypeFace.fontBold.drawCenteredStringWaveXYMove(message, ISAAC.anInt522, Class44.anInt1048, textColor, MovedStatics.anInt2628, -PlayerAppearance.anIntArray684[i] + 150);
                 }
                 if(PlayerAppearance.overheadChatEffect[i] == 4) {
-                    int i_12_ = TypeFace.fontBold.getStringWidth(class1);
+                    int i_12_ = TypeFace.fontBold.getStringWidth(message);
                     int i_13_ = (i_12_ + 100) * (150 + -PlayerAppearance.anIntArray684[i]) / 150;
                     Rasterizer.setBounds(ISAAC.anInt522 + -50, 0, 50 + ISAAC.anInt522, 334);
-                    TypeFace.fontBold.drawString(class1, -i_13_ + ISAAC.anInt522 + 50, Class44.anInt1048 + 1, 0);
-                    TypeFace.fontBold.drawString(class1, 50 + ISAAC.anInt522 + -i_13_, Class44.anInt1048, i_8_);
+                    TypeFace.fontBold.drawString(message, -i_13_ + ISAAC.anInt522 + 50, Class44.anInt1048 + 1, 0);
+                    TypeFace.fontBold.drawString(message, 50 + ISAAC.anInt522 + -i_13_, Class44.anInt1048, textColor);
                     Rasterizer.resetBounds();
                 }
                 if(PlayerAppearance.overheadChatEffect[i] == 5) {
@@ -209,13 +209,13 @@ public class Class33 {
                             i_14_ = i_15_ + -125;
                     } else
                         i_14_ = i_15_ + -25;
-                    TypeFace.fontBold.drawStringLeft(class1, ISAAC.anInt522, i_14_ + Class44.anInt1048 + 1, 0);
-                    TypeFace.fontBold.drawStringLeft(class1, ISAAC.anInt522, i_14_ + Class44.anInt1048, i_8_);
+                    TypeFace.fontBold.drawStringLeft(message, ISAAC.anInt522, i_14_ + Class44.anInt1048 + 1, 0);
+                    TypeFace.fontBold.drawStringLeft(message, ISAAC.anInt522, i_14_ + Class44.anInt1048, textColor);
                     Rasterizer.resetBounds();
                 }
             } else {
-                TypeFace.fontBold.drawStringLeft(class1, ISAAC.anInt522, Class44.anInt1048 + 1, 0);
-                TypeFace.fontBold.drawStringLeft(class1, ISAAC.anInt522, Class44.anInt1048, MovedStatics.OVERHEAD_CHAT_COLORS[0]);
+                TypeFace.fontBold.drawStringLeft(message, ISAAC.anInt522, Class44.anInt1048 + 1, 0);
+                TypeFace.fontBold.drawStringLeft(message, ISAAC.anInt522, Class44.anInt1048, MovedStatics.OVERHEAD_CHAT_COLORS[0]);
             }
         }
     }

--- a/src/main/java/org/runejs/client/Class33.java
+++ b/src/main/java/org/runejs/client/Class33.java
@@ -140,20 +140,20 @@ public class Class33 {
                 if(PlayerAppearance.overheadChatColor[i] < 6)
                     textColor = MovedStatics.OVERHEAD_CHAT_COLORS[PlayerAppearance.overheadChatColor[i]];
                 if(PlayerAppearance.overheadChatColor[i] == 6)
-                    textColor = MovedStatics.anInt2628 % 20 >= 10 ? 16776960 : 16711680;
+                    textColor = MovedStatics.anInt2628 % 20 >= 10 ? MovedStatics.OVERHEAD_CHAT_COLORS[0] : MovedStatics.OVERHEAD_CHAT_COLORS[1];
                 if(PlayerAppearance.overheadChatColor[i] == 7)
-                    textColor = MovedStatics.anInt2628 % 20 < 10 ? 255 : 65535;
+                    textColor = MovedStatics.anInt2628 % 20 < 10 ? 255 : MovedStatics.OVERHEAD_CHAT_COLORS[3];
                 if(PlayerAppearance.overheadChatColor[i] == 8)
                     textColor = MovedStatics.anInt2628 % 20 >= 10 ? 8454016 : 45056;
                 if(PlayerAppearance.overheadChatColor[i] == 9) {
                     int i_9_ = 150 - PlayerAppearance.anIntArray684[i];
                     if(i_9_ >= 50) {
                         if(i_9_ < 100)
-                            textColor = -((-50 + i_9_) * 327680) + 16776960;
+                            textColor = -((-50 + i_9_) * 327680) + MovedStatics.OVERHEAD_CHAT_COLORS[0];
                         else if(i_9_ < 150)
-                            textColor = 65280 + 5 * (i_9_ + -100);
+                            textColor = MovedStatics.OVERHEAD_CHAT_COLORS[2] + 5 * (i_9_ + -100);
                     } else
-                        textColor = 16711680 + 1280 * i_9_;
+                        textColor = MovedStatics.OVERHEAD_CHAT_COLORS[1] + 1280 * i_9_;
                 }
                 if(PlayerAppearance.overheadChatColor[i] == 10) {
                     int i_10_ = 150 + -PlayerAppearance.anIntArray684[i];
@@ -162,19 +162,19 @@ public class Class33 {
                             if(i_10_ < 150)
                                 textColor = 255 - (-(327680 * (i_10_ - 100)) - 500) + -(5 * i_10_);
                         } else
-                            textColor = 16711935 - (327680 * i_10_ - 16384000);
+                            textColor = MovedStatics.OVERHEAD_CHAT_COLORS[4] - (327680 * i_10_ - 16384000);
                     } else
-                        textColor = 5 * i_10_ + 16711680;
+                        textColor = 5 * i_10_ + MovedStatics.OVERHEAD_CHAT_COLORS[1];
                 }
                 if(PlayerAppearance.overheadChatColor[i] == 11) {
                     int i_11_ = -PlayerAppearance.anIntArray684[i] + 150;
                     if(i_11_ >= 50) {
                         if(i_11_ < 100)
-                            textColor = 327685 * (i_11_ - 50) + 65280;
+                            textColor = 327685 * (i_11_ - 50) + MovedStatics.OVERHEAD_CHAT_COLORS[2];
                         else if(i_11_ < 150)
-                            textColor = -((-100 + i_11_) * 327680) + 16777215;
+                            textColor = -((-100 + i_11_) * 327680) + MovedStatics.OVERHEAD_CHAT_COLORS[5];
                     } else
-                        textColor = -(327685 * i_11_) + 16777215;
+                        textColor = -(327685 * i_11_) + MovedStatics.OVERHEAD_CHAT_COLORS[5];
                 }
                 if(PlayerAppearance.overheadChatEffect[i] == 0) {
                     TypeFace.fontBold.drawStringLeft(message, ISAAC.anInt522, Class44.anInt1048 + 1, 0);

--- a/src/main/java/org/runejs/client/Class33.java
+++ b/src/main/java/org/runejs/client/Class33.java
@@ -136,9 +136,9 @@ public class Class33 {
             Class44.anInt1048 = PlayerAppearance.anIntArray685[i] = i_4_;
             String class1 = PlayerAppearance.overheadChatMessage[i];
             if(MovedStatics.chatEffectsDisabled == 0) {
-                int i_8_ = 16776960;
+                int i_8_ = MovedStatics.OVERHEAD_CHAT_COLORS[0];
                 if(PlayerAppearance.overheadChatColor[i] < 6)
-                    i_8_ = MovedStatics.anIntArray2106[PlayerAppearance.overheadChatColor[i]];
+                    i_8_ = MovedStatics.OVERHEAD_CHAT_COLORS[PlayerAppearance.overheadChatColor[i]];
                 if(PlayerAppearance.overheadChatColor[i] == 6)
                     i_8_ = MovedStatics.anInt2628 % 20 >= 10 ? 16776960 : 16711680;
                 if(PlayerAppearance.overheadChatColor[i] == 7)
@@ -215,7 +215,7 @@ public class Class33 {
                 }
             } else {
                 TypeFace.fontBold.drawStringLeft(class1, ISAAC.anInt522, Class44.anInt1048 + 1, 0);
-                TypeFace.fontBold.drawStringLeft(class1, ISAAC.anInt522, Class44.anInt1048, 16776960);
+                TypeFace.fontBold.drawStringLeft(class1, ISAAC.anInt522, Class44.anInt1048, MovedStatics.OVERHEAD_CHAT_COLORS[0]);
             }
         }
     }

--- a/src/main/java/org/runejs/client/Class33.java
+++ b/src/main/java/org/runejs/client/Class33.java
@@ -135,7 +135,7 @@ public class Class33 {
             ISAAC.anInt522 = PlayerAppearance.anIntArray715[i];
             Class44.anInt1048 = PlayerAppearance.anIntArray685[i] = i_4_;
             String class1 = PlayerAppearance.overheadChatMessage[i];
-            if(MovedStatics.anInt2280 == 0) {
+            if(MovedStatics.chatEffectsDisabled == 0) {
                 int i_8_ = 16776960;
                 if(PlayerAppearance.overheadChatColor[i] < 6)
                     i_8_ = MovedStatics.anIntArray2106[PlayerAppearance.overheadChatColor[i]];

--- a/src/main/java/org/runejs/client/MovedStatics.java
+++ b/src/main/java/org/runejs/client/MovedStatics.java
@@ -66,7 +66,7 @@ public class MovedStatics {
     public static int[] anIntArray1445;
     public static ProducingGraphicsBuffer chatboxRight;
     public static int crossY = 0;
-    public static int anInt2280 = 0;
+    public static int chatEffectsDisabled = 0;
     public static int anInt321 = 5063219;
     public static volatile int eventMouseY = -1;
     public static boolean redrawChatbox = false;
@@ -1759,7 +1759,7 @@ public class MovedStatics {
 	            	SoundSystem.updateSoundEffectVolume(varPlayerValue);
 	            }
 	            if(varPlayerType == 6)
-	                anInt2280 = varPlayerValue;
+	                chatEffectsDisabled = varPlayerValue;
 	            if(varPlayerType != 5)
 	                break;
 	            ProducingGraphicsBuffer.oneMouseButton = varPlayerValue;

--- a/src/main/java/org/runejs/client/MovedStatics.java
+++ b/src/main/java/org/runejs/client/MovedStatics.java
@@ -112,7 +112,12 @@ public class MovedStatics {
     public static GameSocket gameServerSocket;
     public static int[][][] tile_height = new int[4][105][105];
     public static IndexedImage aClass40_Sub5_Sub14_Sub2_2105;
-    public static int[] anIntArray2106 = {16776960, 16711680, 65280, 65535, 16711935, 16777215};
+    /**
+     * The overhead chat colours in RGB.
+     *
+     * Yellow, Red, Green, Cyan, Purple, White
+     */
+    public static int[] OVERHEAD_CHAT_COLORS = {16776960, 16711680, 65280, 65535, 16711935, 16777215};
     public static int secondaryCameraVertical = 0;
     public static int[] anIntArray2113 = new int[128];
     public static GameInterface aGameInterface_2116;

--- a/src/main/java/org/runejs/client/media/renderable/actor/PlayerAppearance.java
+++ b/src/main/java/org/runejs/client/media/renderable/actor/PlayerAppearance.java
@@ -18,7 +18,7 @@ public class PlayerAppearance {
     public static int[] anIntArray684 = new int[50];
     public static int[] anIntArray685 = new int[50];
     public static int[] anIntArray688 = new int[50];
-    public static int[] overheadChatEffect = new int[50];
+    public static int[] overheadChatShape = new int[50];
     public static String[] overheadChatMessage = new String[50];
     public static int anInt704 = 0;
     public static int anInt708 = -1;

--- a/src/main/java/org/runejs/client/media/renderable/actor/PlayerAppearance.java
+++ b/src/main/java/org/runejs/client/media/renderable/actor/PlayerAppearance.java
@@ -18,11 +18,11 @@ public class PlayerAppearance {
     public static int[] anIntArray684 = new int[50];
     public static int[] anIntArray685 = new int[50];
     public static int[] anIntArray688 = new int[50];
-    public static int[] anIntArray695 = new int[50];
-    public static String[] aClass1Array697 = new String[50];
+    public static int[] overheadChatEffect = new int[50];
+    public static String[] overheadChatMessage = new String[50];
     public static int anInt704 = 0;
     public static int anInt708 = -1;
-    public static int[] anIntArray712 = new int[50];
+    public static int[] overheadChatColor = new int[50];
     public static ProducingGraphicsBuffer tabPieveLowerRight;
     public static int[] anIntArray715 = new int[50];
     public static GameSocket lostConnectionSocket;


### PR DESCRIPTION
- rename some arrays
- use constants instead of magic numbers (e.g. the `getNetworkCode()` for chat effects, and the `OVERHEAD_CHAT_COLORS` values)
  -  this uses the enums from #96
- rename a varp