### PR TITLE
refactor: convert player updating packet to new message system

### DIFF
--- a/src/main/java/org/runejs/client/media/renderable/actor/Player.java
+++ b/src/main/java/org/runejs/client/media/renderable/actor/Player.java
@@ -15,6 +15,7 @@ import org.runejs.client.language.English;
 import org.runejs.client.language.Native;
 import org.runejs.client.media.renderable.Model;
 import org.runejs.client.net.IncomingPackets;
+import org.runejs.client.net.PacketBuffer;
 import org.runejs.client.scene.tile.SceneTile;
 import org.runejs.client.scene.util.CollisionMap;
 
@@ -113,54 +114,54 @@ public class Player extends Actor {
 
 
 
-    public static void parsePlayerUpdateMasks(Player player, int mask, int playerIndex) {
+    public static void parsePlayerUpdateMasks(PacketBuffer appearanceBuffer, Player player, int mask, int playerIndex) {
         if((0x100 & mask) != 0) { // damage/hitsplat 1
-            int damageType1 = IncomingPackets.incomingPacketBuffer.getUnsignedByte();
-            int damageType2 = IncomingPackets.incomingPacketBuffer.getUnsignedByte();
+            int damageType1 = appearanceBuffer.getUnsignedByte();
+            int damageType2 = appearanceBuffer.getUnsignedByte();
             player.method785(damageType2, MovedStatics.pulseCycle, damageType1);
             player.anInt3139 = 300 + MovedStatics.pulseCycle;
-            player.remainingHitpoints = IncomingPackets.incomingPacketBuffer.getUnsignedByte();
-            player.maximumHitpoints = IncomingPackets.incomingPacketBuffer.getUnsignedByte();
+            player.remainingHitpoints = appearanceBuffer.getUnsignedByte();
+            player.maximumHitpoints = appearanceBuffer.getUnsignedByte();
         }
         if((mask & 0x10) != 0) { // face position
-            player.facePositionX = IncomingPackets.incomingPacketBuffer.getUnsignedShortBE();
-            player.facePositionY = IncomingPackets.incomingPacketBuffer.getUnsignedShortLE();
+            player.facePositionX = appearanceBuffer.getUnsignedShortBE();
+            player.facePositionY = appearanceBuffer.getUnsignedShortLE();
         }
         if((mask & 0x1) != 0) { // animation
-            int animationId = IncomingPackets.incomingPacketBuffer.getUnsignedShortLE();
+            int animationId = appearanceBuffer.getUnsignedShortLE();
             if(animationId == 65535)
                 animationId = -1;
-            int animationDelay = IncomingPackets.incomingPacketBuffer.getUnsignedByte();
+            int animationDelay = appearanceBuffer.getUnsignedByte();
             ActorDefinition.playAnimation(animationId, animationDelay, player);
         }
         if((mask & 0x4) != 0) { // face actor
-            player.facingActorIndex = IncomingPackets.incomingPacketBuffer.getUnsignedShortBE();
+            player.facingActorIndex = appearanceBuffer.getUnsignedShortBE();
             if(player.facingActorIndex == 65535)
                 player.facingActorIndex = -1;
         }
         if((0x40 & mask) != 0) { // damage/hitsplat 2
-            int damageType1 = IncomingPackets.incomingPacketBuffer.getUnsignedByte();
-            int damageType2 = IncomingPackets.incomingPacketBuffer.getUnsignedByte();
+            int damageType1 = appearanceBuffer.getUnsignedByte();
+            int damageType2 = appearanceBuffer.getUnsignedByte();
             player.method785(damageType2, MovedStatics.pulseCycle, damageType1);
             player.anInt3139 = 300 + MovedStatics.pulseCycle;
-            player.remainingHitpoints = IncomingPackets.incomingPacketBuffer.getUnsignedByte();
-            player.maximumHitpoints = IncomingPackets.incomingPacketBuffer.getUnsignedByte();
+            player.remainingHitpoints = appearanceBuffer.getUnsignedByte();
+            player.maximumHitpoints = appearanceBuffer.getUnsignedByte();
         }
         if((mask & 0x400) != 0) { // Forced movement?
-            player.anInt3125 = IncomingPackets.incomingPacketBuffer.getUnsignedByte();
-            player.anInt3081 = IncomingPackets.incomingPacketBuffer.getUnsignedByte();
-            player.anInt3099 = IncomingPackets.incomingPacketBuffer.getUnsignedByte();
-            player.anInt3127 = IncomingPackets.incomingPacketBuffer.getUnsignedByte();
-            player.anInt3112 = IncomingPackets.incomingPacketBuffer.getUnsignedShortBE() + MovedStatics.pulseCycle;
-            player.anInt3107 = IncomingPackets.incomingPacketBuffer.getUnsignedShortLE() + MovedStatics.pulseCycle;
-            player.anInt3073 = IncomingPackets.incomingPacketBuffer.getUnsignedByte();
+            player.anInt3125 = appearanceBuffer.getUnsignedByte();
+            player.anInt3081 = appearanceBuffer.getUnsignedByte();
+            player.anInt3099 = appearanceBuffer.getUnsignedByte();
+            player.anInt3127 = appearanceBuffer.getUnsignedByte();
+            player.anInt3112 = appearanceBuffer.getUnsignedShortBE() + MovedStatics.pulseCycle;
+            player.anInt3107 = appearanceBuffer.getUnsignedShortLE() + MovedStatics.pulseCycle;
+            player.anInt3073 = appearanceBuffer.getUnsignedByte();
             player.method790(0);
         }
         if((0x8 & mask) != 0) { // chat
-            int chatEffectsAndColors = IncomingPackets.incomingPacketBuffer.getUnsignedShortBE();
-            int playerRights = IncomingPackets.incomingPacketBuffer.getUnsignedByte();
-            int messageLength = IncomingPackets.incomingPacketBuffer.getUnsignedByte();
-            int bufferPosition = IncomingPackets.incomingPacketBuffer.currentPosition;
+            int chatEffectsAndColors = appearanceBuffer.getUnsignedShortBE();
+            int playerRights = appearanceBuffer.getUnsignedByte();
+            int messageLength = appearanceBuffer.getUnsignedByte();
+            int bufferPosition = appearanceBuffer.currentPosition;
             if(player.playerName != null && player.playerAppearance != null) {
                 long l = RSString.nameToLong(player.playerName);
                 boolean bool = false;
@@ -174,9 +175,9 @@ public class Player extends Actor {
                 }
                 if(!bool && !inTutorialIsland) {
                     chatBuffer.currentPosition = 0;
-                    IncomingPackets.incomingPacketBuffer.getBytes(0, messageLength, chatBuffer.buffer);
+                    appearanceBuffer.getBytes(0, messageLength, chatBuffer.buffer);
                     chatBuffer.currentPosition = 0;
-                    String incomming = KeyFocusListener.method956(IncomingPackets.incomingPacketBuffer);
+                    String incomming = KeyFocusListener.method956(appearanceBuffer);
                     String class1 = RSString.formatChatString(incomming);
                     player.forcedChatMessage = class1.trim();
                     player.anInt3078 = 150;
@@ -190,19 +191,19 @@ public class Player extends Actor {
                         ChatBox.addChatMessage(player.playerName, class1, 2);
                 }
             }
-            IncomingPackets.incomingPacketBuffer.currentPosition = messageLength + bufferPosition;
+            appearanceBuffer.currentPosition = messageLength + bufferPosition;
         }
         if((0x20 & mask) != 0) { // appearance
-            int appearanceUpdateLength = IncomingPackets.incomingPacketBuffer.getUnsignedByte();
+            int appearanceUpdateLength = appearanceBuffer.getUnsignedByte();
             byte[] is = new byte[appearanceUpdateLength];
             Buffer buffer = new Buffer(is);
-            IncomingPackets.incomingPacketBuffer.getBytes(appearanceUpdateLength, 0, is);
+            appearanceBuffer.getBytes(appearanceUpdateLength, 0, is);
             trackedPlayerAppearanceCache[playerIndex] = buffer;
             player.parsePlayerAppearanceData(buffer);
         }
         if((mask & 0x200) != 0) { // graphics
-            player.graphicId = IncomingPackets.incomingPacketBuffer.getUnsignedShortLE();
-            int graphicData = IncomingPackets.incomingPacketBuffer.getIntBE();
+            player.graphicId = appearanceBuffer.getUnsignedShortLE();
+            int graphicData = appearanceBuffer.getIntBE();
             player.anInt3129 = 0;
             player.graphicDelay = MovedStatics.pulseCycle + (graphicData & 0xffff);
             if(player.graphicId == 65535)
@@ -213,7 +214,7 @@ public class Player extends Actor {
                 player.anInt3140 = -1;
         }
         if((0x80 & mask) != 0) { // forced chat
-            player.forcedChatMessage = IncomingPackets.incomingPacketBuffer.getString();
+            player.forcedChatMessage = appearanceBuffer.getString();
             if(player.forcedChatMessage.charAt(0) == 126) {
                 player.forcedChatMessage = player.forcedChatMessage.substring(1);
                 ChatBox.addChatMessage(player.playerName, player.forcedChatMessage, 2);
@@ -225,14 +226,14 @@ public class Player extends Actor {
         }
     }
 
-    public static void parseTrackedPlayerUpdateMasks() {
+    public static void parseTrackedPlayerUpdateMasks(PacketBuffer appearanceBuffer) {
         for(int i = 0; i < actorUpdatingIndex; i++) {
             int trackedPlayerIndex = actorUpdatingIndices[i];
             Player player = trackedPlayers[trackedPlayerIndex];
-            int mask = IncomingPackets.incomingPacketBuffer.getUnsignedByte();
+            int mask = appearanceBuffer.getUnsignedByte();
             if((mask & 0x2) != 0)
-                mask += IncomingPackets.incomingPacketBuffer.getUnsignedByte() << 8;
-            parsePlayerUpdateMasks(player, mask, trackedPlayerIndex);
+                mask += appearanceBuffer.getUnsignedByte() << 8;
+            parsePlayerUpdateMasks(appearanceBuffer, player, mask, trackedPlayerIndex);
         }
     }
 

--- a/src/main/java/org/runejs/client/message/handler/rs435/RS435HandlerRegistry.java
+++ b/src/main/java/org/runejs/client/message/handler/rs435/RS435HandlerRegistry.java
@@ -1,20 +1,19 @@
 package org.runejs.client.message.handler.rs435;
 
 import org.runejs.client.message.handler.MessageHandlerRegistry;
+import org.runejs.client.message.handler.rs435.audio.*;
+import org.runejs.client.message.inbound.audio.*;
 import org.runejs.client.message.handler.rs435.chat.*;
 import org.runejs.client.message.inbound.chat.*;
-import org.runejs.client.message.handler.rs435.audio.PlayQuickSongMessageHandler;
-import org.runejs.client.message.handler.rs435.audio.PlaySongMessageHandler;
-import org.runejs.client.message.handler.rs435.audio.PlaySoundMessageHandler;
-import org.runejs.client.message.inbound.audio.PlayQuickSongInboundMessage;
-import org.runejs.client.message.inbound.audio.PlaySongInboundMessage;
-import org.runejs.client.message.inbound.audio.PlaySoundInboundMessage;
+import org.runejs.client.message.inbound.updating.UpdatePlayersInboundMessage;
 
 /**
  * A {@link MessageHandlerRegistry} for the RS revision 435 client.
  */
 public class RS435HandlerRegistry extends MessageHandlerRegistry {
     public RS435HandlerRegistry() {
+        super();
+
         register(ReceivePrivateMessageInboundMessage.class, new ReceivePrivateMessageHandler());
         register(ReceiveChatboxMessageInboundMessage.class, new ReceiveChatboxMessageHandler());
         register(ForcedPrivateMessageInboundMessage.class, new ForcedPrivateMessageHandler());
@@ -24,5 +23,7 @@ public class RS435HandlerRegistry extends MessageHandlerRegistry {
         register(PlaySongInboundMessage.class, new PlaySongMessageHandler());
         register(PlayQuickSongInboundMessage.class, new PlayQuickSongMessageHandler());
         register(PlaySoundInboundMessage.class, new PlaySoundMessageHandler());
+
+        register(UpdatePlayersInboundMessage.class, new UpdatePlayersMessageHandler());
     }
 }

--- a/src/main/java/org/runejs/client/message/handler/rs435/UpdatePlayersMessageHandler.java
+++ b/src/main/java/org/runejs/client/message/handler/rs435/UpdatePlayersMessageHandler.java
@@ -2,7 +2,9 @@ package org.runejs.client.message.handler.rs435;
 
 import org.runejs.client.Class17;
 import org.runejs.client.media.renderable.actor.Actor;
+import org.runejs.client.media.renderable.actor.Player;
 import org.runejs.client.message.handler.MessageHandler;
+import org.runejs.client.message.inbound.updating.LocalPlayerMovementUpdate;
 import org.runejs.client.message.inbound.updating.UpdatePlayersInboundMessage;
 
 /**
@@ -18,8 +20,10 @@ public class UpdatePlayersMessageHandler implements MessageHandler<UpdatePlayers
         // initialisation steps for player updating
         Actor.actorUpdatingIndex = 0;
         Class17.deregisterActorCount = 0;
+        
+        // handle the different types of update within the message
+        handleLocalPlayerMovement(message.localPlayerMovement);
 
-        // TODO handle message here
         // handle any deregistrations
         for(int i = 0; Class17.deregisterActorCount > i; i++) {
             int trackedPlayerIndex = Player.deregisterActorIndices[i];
@@ -33,5 +37,58 @@ public class UpdatePlayersMessageHandler implements MessageHandler<UpdatePlayers
             if(Player.trackedPlayers[Player.trackedPlayerIndices[i]] == null)
                 throw new RuntimeException("gpp2 pos:" + i + " size:" + Player.localPlayerCount);
         }
+    }
+
+    /**
+     * Responsible for applying movement to the client's local player.
+     * 
+     * @param update The update method
+     */
+    private void handleLocalPlayerMovement(LocalPlayerMovementUpdate update) {
+        // if there is no update at all we do nothing
+        if (update == null) {
+            return;
+        }
+
+        if (update.mapRegionUpdate == null && update.movementUpdate == null) {
+            // "no movement" is handled differently to "no update", and needs this to be set
+            // this is indicated by mapRegionUpdate and movementUpdate both being null
+            Player.actorUpdatingIndices[Player.actorUpdatingIndex++] = 2047;
+            return;
+        }
+
+        // map region updates
+        if (update.mapRegionUpdate != null) {
+            Player.worldLevel = update.mapRegionUpdate.level;
+
+            if (update.mapRegionUpdate.runUpdateBlock) {
+                Player.actorUpdatingIndices[Player.actorUpdatingIndex++] = 2047;
+            }
+            
+            Player.localPlayer.method787(update.mapRegionUpdate.localChunkY, -7717, update.mapRegionUpdate.teleporting, update.mapRegionUpdate.localChunkX);
+
+            return;
+        }
+
+        // general movement updates (walking etc)
+        if (update.movementUpdate != null) {
+            PlayerMovementUpdate playerMovementUpdate = update.movementUpdate;
+
+            if (playerMovementUpdate.runDirection != null) {
+                Player.localPlayer.move(playerMovementUpdate.walkDirection, true);
+                Player.localPlayer.move(playerMovementUpdate.runDirection, true);
+            } else {
+                Player.localPlayer.move(playerMovementUpdate.walkDirection, false);
+            }
+
+            if (playerMovementUpdate.runUpdateBlock) {
+                Player.actorUpdatingIndices[Player.actorUpdatingIndex++] = 2047;
+            }
+
+            return;
+        }
+
+        // code should never reach here based on if statements above
+        throw new RuntimeException("Unhandled local player movement update");
     }
 }

--- a/src/main/java/org/runejs/client/message/handler/rs435/UpdatePlayersMessageHandler.java
+++ b/src/main/java/org/runejs/client/message/handler/rs435/UpdatePlayersMessageHandler.java
@@ -34,8 +34,13 @@ public class UpdatePlayersMessageHandler implements MessageHandler<UpdatePlayers
 
         handleRegisterNewPlayers(message.newPlayers);
         
-        // TODO handle others
-        
+        /**
+         * We call into the original method here to keep this implementation simple.
+         * 
+         * In future, we should refactor this to be a part of the message handling system also.
+         */
+        Player.parseTrackedPlayerUpdateMasks(message.appearanceUpdates);
+
         // handle any deregistrations
         for(int i = 0; Class17.deregisterActorCount > i; i++) {
             int trackedPlayerIndex = Player.deregisterActorIndices[i];

--- a/src/main/java/org/runejs/client/message/handler/rs435/UpdatePlayersMessageHandler.java
+++ b/src/main/java/org/runejs/client/message/handler/rs435/UpdatePlayersMessageHandler.java
@@ -1,11 +1,15 @@
 package org.runejs.client.message.handler.rs435;
 
 import org.runejs.client.Class17;
+import org.runejs.client.MovedStatics;
 import org.runejs.client.media.renderable.actor.Actor;
 import org.runejs.client.media.renderable.actor.Player;
 import org.runejs.client.message.handler.MessageHandler;
 import org.runejs.client.message.inbound.updating.LocalPlayerMovementUpdate;
+import org.runejs.client.message.inbound.updating.OtherPlayersMovementUpdate;
+import org.runejs.client.message.inbound.updating.PlayerMovementUpdate;
 import org.runejs.client.message.inbound.updating.UpdatePlayersInboundMessage;
+import org.runejs.client.message.inbound.updating.OtherPlayersMovementUpdate.OtherPlayerMovementUpdate;
 
 /**
  * Applies the main "player updating" message to the game state.
@@ -23,7 +27,10 @@ public class UpdatePlayersMessageHandler implements MessageHandler<UpdatePlayers
         
         // handle the different types of update within the message
         handleLocalPlayerMovement(message.localPlayerMovement);
+        handleOtherPlayersMovement(message.otherPlayersMovement);
 
+        // TODO handle others
+        
         // handle any deregistrations
         for(int i = 0; Class17.deregisterActorCount > i; i++) {
             int trackedPlayerIndex = Player.deregisterActorIndices[i];
@@ -42,7 +49,7 @@ public class UpdatePlayersMessageHandler implements MessageHandler<UpdatePlayers
     /**
      * Responsible for applying movement to the client's local player.
      * 
-     * @param update The update method
+     * @param update The update information to apply
      */
     private void handleLocalPlayerMovement(LocalPlayerMovementUpdate update) {
         // if there is no update at all we do nothing
@@ -91,4 +98,70 @@ public class UpdatePlayersMessageHandler implements MessageHandler<UpdatePlayers
         // code should never reach here based on if statements above
         throw new RuntimeException("Unhandled local player movement update");
     }
+
+    /**
+     * Handle the movement/placement of other (already tracked) players.
+     * 
+     * This method is pulled from the original implementation with minimal changes.
+     * 
+     * @param update The update information to apply
+     */
+    private void handleOtherPlayersMovement(OtherPlayersMovementUpdate update) {
+        int trackedPlayerCount = update.playerCount;
+        if(trackedPlayerCount < Player.localPlayerCount) {
+            for(int i = trackedPlayerCount; Player.localPlayerCount > i; i++)
+                Player.deregisterActorIndices[Class17.deregisterActorCount++] = Player.trackedPlayerIndices[i];
+        }
+        
+        if(Player.localPlayerCount < trackedPlayerCount) {
+            System.out.println("gppov1 " + Player.localPlayerCount + " " + trackedPlayerCount);
+            throw new RuntimeException("gppov1");
+        }
+
+        Player.localPlayerCount = 0;
+
+        for(int i = 0; trackedPlayerCount > i; i++) {
+            int trackedPlayerIndex = Player.trackedPlayerIndices[i];
+            Player player = Player.trackedPlayers[trackedPlayerIndex];
+
+            OtherPlayerMovementUpdate playerUpdate = update.movementUpdates[i];
+            
+            // no update required
+            if (playerUpdate == null) {
+                Player.trackedPlayerIndices[Player.localPlayerCount++] = trackedPlayerIndex;
+                player.anInt3134 = MovedStatics.pulseCycle;
+                continue;
+            }
+
+            // deregister player if necessary
+            if (playerUpdate.shouldDeregister) {
+                Player.deregisterActorIndices[Class17.deregisterActorCount++] = trackedPlayerIndex;
+                continue;
+            }
+            
+            Player.trackedPlayerIndices[Player.localPlayerCount++] = trackedPlayerIndex;
+            player.anInt3134 = MovedStatics.pulseCycle;
+
+            // if no movement then we can skip the rest
+            if (playerUpdate.movementUpdate == null) {
+                Player.actorUpdatingIndices[Player.actorUpdatingIndex++] = trackedPlayerIndex;
+                continue;
+            }
+
+            // handle the player movement
+            PlayerMovementUpdate movementUpdate = playerUpdate.movementUpdate;
+
+            if (movementUpdate.runDirection != null) {
+                player.move(movementUpdate.walkDirection, true);
+                player.move(movementUpdate.runDirection, true);
+            } else {
+                player.move(movementUpdate.walkDirection, false);
+            }
+
+            if (movementUpdate.runUpdateBlock) {
+                Player.actorUpdatingIndices[Player.actorUpdatingIndex++] = trackedPlayerIndex;
+            }
+        }
+    }
+
 }

--- a/src/main/java/org/runejs/client/message/handler/rs435/UpdatePlayersMessageHandler.java
+++ b/src/main/java/org/runejs/client/message/handler/rs435/UpdatePlayersMessageHandler.java
@@ -1,0 +1,37 @@
+package org.runejs.client.message.handler.rs435;
+
+import org.runejs.client.Class17;
+import org.runejs.client.media.renderable.actor.Actor;
+import org.runejs.client.message.handler.MessageHandler;
+import org.runejs.client.message.inbound.updating.UpdatePlayersInboundMessage;
+
+/**
+ * Applies the main "player updating" message to the game state.
+ * 
+ * Reponsible for registering and deregistering players, as well
+ * as updating their movement and appearance.
+ */
+public class UpdatePlayersMessageHandler implements MessageHandler<UpdatePlayersInboundMessage> {
+
+    @Override
+    public void handle(UpdatePlayersInboundMessage message) {
+        // initialisation steps for player updating
+        Actor.actorUpdatingIndex = 0;
+        Class17.deregisterActorCount = 0;
+
+        // TODO handle message here
+        // handle any deregistrations
+        for(int i = 0; Class17.deregisterActorCount > i; i++) {
+            int trackedPlayerIndex = Player.deregisterActorIndices[i];
+            if(MovedStatics.pulseCycle != Player.trackedPlayers[trackedPlayerIndex].anInt3134)
+                Player.trackedPlayers[trackedPlayerIndex] = null;
+        }
+
+        // check that the tracked player list is valid
+        int i = 0;
+        for(/**/; Player.localPlayerCount > i; i++) {
+            if(Player.trackedPlayers[Player.trackedPlayerIndices[i]] == null)
+                throw new RuntimeException("gpp2 pos:" + i + " size:" + Player.localPlayerCount);
+        }
+    }
+}

--- a/src/main/java/org/runejs/client/message/inbound/updating/LocalPlayerMovementUpdate.java
+++ b/src/main/java/org/runejs/client/message/inbound/updating/LocalPlayerMovementUpdate.java
@@ -1,0 +1,68 @@
+package org.runejs.client.message.inbound.updating;
+
+/**
+ * The update message containing the local player's movement.
+ */
+public class LocalPlayerMovementUpdate {
+    /**
+     * The map region change update for the local player.
+     * 
+     * Used when the player is teleporting or changing levels (movement type 3)
+     */
+    public static class LocalPlayerMapRegionChangeUpdate {
+        /**
+         * Whether the player is teleporting.
+         */
+        public final boolean teleporting;
+
+        /**
+         * The world level.
+         */
+        public final int level;
+
+        /**
+         * The local chunk X coordinate.
+         */
+        public final int localChunkX;
+
+        /**
+         * The local chunk Y coordinate.
+         */
+        public final int localChunkY;
+
+        /**
+         * Whether to run the update block.
+         */
+        public final boolean runUpdateBlock;
+
+        public LocalPlayerMapRegionChangeUpdate(boolean teleporting, int level, boolean runUpdateBlock, int localChunkX, int localChunkY) {
+            this.teleporting = teleporting;
+            this.level = level;
+            this.runUpdateBlock = runUpdateBlock;
+            this.localChunkX = localChunkX;
+            this.localChunkY = localChunkY;
+        }
+    }
+
+    /**
+     * The local player movement update.
+     * 
+     * This will be null if the player is not moving.
+     */
+    public final PlayerMovementUpdate movementUpdate;
+
+    /**
+     * The local player map region change update.
+     * 
+     * This will be null if the player does not need to change map regions.
+     */
+    public final LocalPlayerMapRegionChangeUpdate mapRegionUpdate;
+
+    public LocalPlayerMovementUpdate(PlayerMovementUpdate movementUpdate, LocalPlayerMapRegionChangeUpdate mapRegionUpdate) {
+        if (movementUpdate != null && mapRegionUpdate != null)
+            throw new IllegalArgumentException("Cannot have both a local player movement update and a local player map region change update.");
+
+        this.movementUpdate = movementUpdate;
+        this.mapRegionUpdate = mapRegionUpdate;
+    }
+}

--- a/src/main/java/org/runejs/client/message/inbound/updating/OtherPlayersMovementUpdate.java
+++ b/src/main/java/org/runejs/client/message/inbound/updating/OtherPlayersMovementUpdate.java
@@ -1,0 +1,43 @@
+package org.runejs.client.message.inbound.updating;
+
+/**
+ * The update message containing movement updates for all non-local players.
+ */
+public class OtherPlayersMovementUpdate {
+    /**
+     * Movement update details for a single non-local player.
+     */
+    public static class OtherPlayerMovementUpdate {
+        /**
+         * The local player movement update.
+         * 
+         * This will be null if the player is not moving.
+         */
+        public final PlayerMovementUpdate movementUpdate;
+    
+        /**
+         * Whether the player should be deregistered.
+         */
+        public final boolean shouldDeregister;
+
+        public OtherPlayerMovementUpdate(PlayerMovementUpdate movementUpdate, boolean shouldDeregister) {
+            this.movementUpdate = movementUpdate;
+            this.shouldDeregister = shouldDeregister;
+        }
+    }
+
+    /**
+     * The number of players contained in this update.
+     */
+    public final int playerCount;
+
+    /**
+     * The movement updates for each player.
+     */
+    public final OtherPlayerMovementUpdate[] movementUpdates;
+
+    public OtherPlayersMovementUpdate(int playerCount, OtherPlayerMovementUpdate[] movementUpdates) {
+        this.playerCount = playerCount;
+        this.movementUpdates = movementUpdates;
+    }
+}

--- a/src/main/java/org/runejs/client/message/inbound/updating/PlayerMovementUpdate.java
+++ b/src/main/java/org/runejs/client/message/inbound/updating/PlayerMovementUpdate.java
@@ -1,0 +1,31 @@
+package org.runejs.client.message.inbound.updating;
+
+/**
+ * The standard movement update for a player.
+ * 
+ * Used when the player is walking or running (movement types 1 and 2)
+ */
+public class PlayerMovementUpdate {
+    /**
+     * The walk direction.
+     */
+    public final int walkDirection;
+
+    /**
+     * The run direction.
+     * 
+     * This is an Integer because it can be null if the player is not running.
+     */
+    public final Integer runDirection;
+
+    /**
+     * Whether to run the update block.
+     */
+    public final boolean runUpdateBlock;
+
+    public PlayerMovementUpdate(int walkDirection, Integer runDirection, boolean runUpdateBlock) {
+        this.walkDirection = walkDirection;
+        this.runDirection = runDirection;
+        this.runUpdateBlock = runUpdateBlock;
+    }
+}

--- a/src/main/java/org/runejs/client/message/inbound/updating/RegisterNewPlayersUpdate.java
+++ b/src/main/java/org/runejs/client/message/inbound/updating/RegisterNewPlayersUpdate.java
@@ -1,0 +1,59 @@
+package org.runejs.client.message.inbound.updating;
+
+/**
+ * The update message containing details about new players that should be registered.
+ */
+public class RegisterNewPlayersUpdate {
+    /**
+     * The update details for a single new player.
+     */
+    public static class RegisterNewPlayerUpdate {
+        /**
+         * The index of the player.
+         */
+        public final int playerIndex;
+
+        /**
+         * The offset X coordinate.
+         */
+        public final int offsetX;
+
+        /**
+         * The offset Y coordinate.
+         */
+        public final int offsetY;
+
+        /**
+         * The facing direction of the player.
+         */
+        public final int faceDirection;
+
+        /**
+         * Whether the player requires an update.
+         */
+        public final boolean updateRequired;
+
+        /**
+         * Whether to discard the walking queue.
+         */
+        public final boolean discardWalkingQueue;
+
+        public RegisterNewPlayerUpdate(int playerIndex, int offsetX, int offsetY, int faceDirection, boolean updateRequired, boolean discardWalkingQueue) {
+            this.playerIndex = playerIndex;
+            this.offsetX = offsetX;
+            this.offsetY = offsetY;
+            this.faceDirection = faceDirection;
+            this.updateRequired = updateRequired;
+            this.discardWalkingQueue = discardWalkingQueue;
+        }
+    }
+
+    /**
+     * The list of new players that should be registered.
+     */
+    public final RegisterNewPlayerUpdate[] players;
+
+    public RegisterNewPlayersUpdate(RegisterNewPlayerUpdate[] players) {
+        this.players = players;
+    }
+}

--- a/src/main/java/org/runejs/client/message/inbound/updating/UpdatePlayersInboundMessage.java
+++ b/src/main/java/org/runejs/client/message/inbound/updating/UpdatePlayersInboundMessage.java
@@ -1,0 +1,39 @@
+package org.runejs.client.message.inbound.updating;
+
+import org.runejs.client.message.InboundMessage;
+import org.runejs.client.net.PacketBuffer;
+
+/**
+ * The inbound message containing updates for all players, including the local player.
+ */
+public class UpdatePlayersInboundMessage implements InboundMessage {
+    /**
+     * The movement update for the local player.
+     */
+    public final LocalPlayerMovementUpdate localPlayerMovement;
+
+    /**
+     * The movement updates for all non-local players.
+     */
+    public final OtherPlayersMovementUpdate otherPlayersMovement;
+
+    /**
+     * The new players to register.
+     */
+    public final RegisterNewPlayersUpdate newPlayers;
+
+    /**
+     * The appearance updates for the players.
+     * 
+     * TODO (James) we should create a class to contain this rather than using a `PacketBuffer`,
+     * but it's a lot of work for now. Revisit this later.
+     */
+    public final PacketBuffer appearanceUpdates;
+
+    public UpdatePlayersInboundMessage(LocalPlayerMovementUpdate localPlayerMovement, OtherPlayersMovementUpdate otherPlayersMovement, RegisterNewPlayersUpdate newPlayers, PacketBuffer appearanceUpdates) {
+        this.localPlayerMovement = localPlayerMovement;
+        this.otherPlayersMovement = otherPlayersMovement;
+        this.newPlayers = newPlayers;
+        this.appearanceUpdates = appearanceUpdates;
+    }
+}

--- a/src/main/java/org/runejs/client/net/IncomingPackets.java
+++ b/src/main/java/org/runejs/client/net/IncomingPackets.java
@@ -1010,27 +1010,6 @@ public class IncomingPackets {
         }
     }
 
-    public static void parsePlayerUpdatePacket() {
-        Actor.actorUpdatingIndex = 0;
-        Class17.deregisterActorCount = 0;
-        Player.parsePlayerMovement();
-        Player.parseTrackedPlayerMovement();
-        Player.registerNewPlayers();
-        Player.parseTrackedPlayerUpdateMasks(IncomingPackets.incomingPacketBuffer);
-        for(int i = 0; Class17.deregisterActorCount > i; i++) {
-            int trackedPlayerIndex = Player.deregisterActorIndices[i];
-            if(MovedStatics.pulseCycle != Player.trackedPlayers[trackedPlayerIndex].anInt3134)
-                Player.trackedPlayers[trackedPlayerIndex] = null;
-        }
-        if(incomingPacketSize != incomingPacketBuffer.currentPosition)
-            throw new RuntimeException("gpp1 pos:" + incomingPacketBuffer.currentPosition + " psize:" + incomingPacketSize);
-        int i = 0;
-        for(/**/; Player.localPlayerCount > i; i++) {
-            if(Player.trackedPlayers[Player.trackedPlayerIndices[i]] == null)
-                throw new RuntimeException("gpp2 pos:" + i + " size:" + Player.localPlayerCount);
-        }
-    }
-
     public static void parseMapIncomingPacket() {
         if (opcode == 49) {
             int i = incomingPacketBuffer.getUnsignedByte();

--- a/src/main/java/org/runejs/client/net/IncomingPackets.java
+++ b/src/main/java/org/runejs/client/net/IncomingPackets.java
@@ -98,6 +98,10 @@ public class IncomingPackets {
                 // decode the packet and handle it
                 InboundMessage message = decoder.decode(packetBuffer);
                 MessageHandler handler = Main.handlerRegistry.getMessageHandler(message.getClass());
+
+                if (handler == null)
+                    throw new RuntimeException("No handler for message: " + message.getClass().getName());
+
                 handler.handle(message);
 
                 opcode = -1;

--- a/src/main/java/org/runejs/client/net/IncomingPackets.java
+++ b/src/main/java/org/runejs/client/net/IncomingPackets.java
@@ -1021,7 +1021,7 @@ public class IncomingPackets {
         Player.parsePlayerMovement();
         Player.parseTrackedPlayerMovement();
         Player.registerNewPlayers();
-        Player.parseTrackedPlayerUpdateMasks();
+        Player.parseTrackedPlayerUpdateMasks(IncomingPackets.incomingPacketBuffer);
         for(int i = 0; Class17.deregisterActorCount > i; i++) {
             int trackedPlayerIndex = Player.deregisterActorIndices[i];
             if(MovedStatics.pulseCycle != Player.trackedPlayers[trackedPlayerIndex].anInt3134)

--- a/src/main/java/org/runejs/client/net/IncomingPackets.java
+++ b/src/main/java/org/runejs/client/net/IncomingPackets.java
@@ -606,11 +606,6 @@ public class IncomingPackets {
                 opcode = -1;
                 return true;
             }
-            if(opcode == PacketType.UPDATE_PLAYERS.getOpcode()) {
-                parsePlayerUpdatePacket();
-                opcode = -1;
-                return true;
-            }
             if(opcode == 2) {
                 int varPlayerValue = incomingPacketBuffer.getIntBE();
                 int varPlayerIndex = incomingPacketBuffer.getUnsignedShortBE();

--- a/src/main/java/org/runejs/client/net/codec/runejs435/RuneJS435PacketCodec.java
+++ b/src/main/java/org/runejs/client/net/codec/runejs435/RuneJS435PacketCodec.java
@@ -8,6 +8,7 @@ import org.runejs.client.net.codec.runejs435.decoder.audio.*;
 import org.runejs.client.net.codec.runejs435.decoder.chat.*;
 import org.runejs.client.net.codec.runejs435.encoder.chat.*;
 import org.runejs.client.net.codec.runejs435.encoder.interactions.*;
+import org.runejs.client.net.codec.runejs435.decoder.updating.UpdatePlayersMessageDecoder;
 
 /**
  * A {@link MessagePacketCodec} for the RuneJS customised 435 protocol.
@@ -38,5 +39,7 @@ public class RuneJS435PacketCodec extends MessagePacketCodec {
         register(PacketType.PLAY_SONG.getOpcode(), new PlaySongMessageDecoder());
         register(PacketType.PLAY_QUICK_SONG.getOpcode(), new PlayQuickSongMessageDecoder());
         register(PacketType.PLAY_SOUND.getOpcode(), new PlaySoundMessageDecoder());
+        
+        register(PacketType.UPDATE_PLAYERS.getOpcode(), new UpdatePlayersMessageDecoder());
     }
 }

--- a/src/main/java/org/runejs/client/net/codec/runejs435/decoder/updating/UpdatePlayersMessageDecoder.java
+++ b/src/main/java/org/runejs/client/net/codec/runejs435/decoder/updating/UpdatePlayersMessageDecoder.java
@@ -34,11 +34,14 @@ public class UpdatePlayersMessageDecoder implements MessageDecoder<UpdatePlayers
         RegisterNewPlayersUpdate registerNewPlayers = decodeRegisterNewPlayersUpdate(buffer);
         buffer.finishBitAccess();
 
+        // the remaining bytes in the buffer are the appearance update
+        PacketBuffer appearanceUpdate = decodeRemainingBytes(buffer);
+
         return new UpdatePlayersInboundMessage(
                 localPlayerMovement,
                 otherPlayersMovement,
                 registerNewPlayers,
-                null);
+                appearanceUpdate);
     }
 
     /**
@@ -189,9 +192,29 @@ public class UpdatePlayersMessageDecoder implements MessageDecoder<UpdatePlayers
             updates.add(new RegisterNewPlayerUpdate(newPlayerIndex, offsetX, offsetY, initialFaceDirection,
                     updateRequired, discardWalkingQueue));
         }
-        buffer.finishBitAccess();
 
         return new RegisterNewPlayersUpdate(updates.toArray(new RegisterNewPlayerUpdate[updates.size()]));
+    }
+
+    /**
+     * Decodes the remaining bytes in the buffer into a new buffer
+     * 
+     * This is used for the appearance update
+     * 
+     * @param buffer The buffer to decode the remaining bytes from
+     * @return A new buffer containing the remaining bytes
+     */
+    private PacketBuffer decodeRemainingBytes(PacketBuffer buffer) {
+        // 5000 bytes is the length previously used in IncomingPackets
+        // we can probably refactor to use a smaller/dynamic length in future
+        int REMAINING_BYTES_LENGTH = 5000;
+
+        int remainingBytes = buffer.getSize() - buffer.currentPosition;
+        PacketBuffer remainingBuffer = new PacketBuffer(REMAINING_BYTES_LENGTH);
+        System.arraycopy(buffer.buffer, buffer.currentPosition, remainingBuffer.buffer, 0, remainingBytes);
+        remainingBuffer.currentPosition = 0;
+
+        return remainingBuffer;
     }
 
 }

--- a/src/main/java/org/runejs/client/net/codec/runejs435/decoder/updating/UpdatePlayersMessageDecoder.java
+++ b/src/main/java/org/runejs/client/net/codec/runejs435/decoder/updating/UpdatePlayersMessageDecoder.java
@@ -1,0 +1,98 @@
+package org.runejs.client.net.codec.runejs435.decoder.updating;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.runejs.client.message.inbound.updating.LocalPlayerMovementUpdate;
+import org.runejs.client.message.inbound.updating.PlayerMovementUpdate;
+import org.runejs.client.message.inbound.updating.UpdatePlayersInboundMessage;
+import org.runejs.client.message.inbound.updating.LocalPlayerMovementUpdate.LocalPlayerMapRegionChangeUpdate;
+import org.runejs.client.net.PacketBuffer;
+import org.runejs.client.net.codec.MessageDecoder;
+
+/**
+ * Decodes the {@link UpdatePlayersInboundMessage}.
+ * 
+ * This message is sent by the server to update the local player and
+ * other surrounding players.
+ */
+public class UpdatePlayersMessageDecoder implements MessageDecoder<UpdatePlayersInboundMessage> {
+
+    /**
+     * Decodes a {@link PacketBuffer} into a {@link UpdatePlayersInboundMessage},
+     * which can then be processed by the game.
+     */
+    @Override
+    public UpdatePlayersInboundMessage decode(PacketBuffer buffer) {
+        buffer.initBitAccess();
+        LocalPlayerMovementUpdate localPlayerMovement = decodeLocalPlayerMovementUpdate(buffer);
+        buffer.finishBitAccess();
+
+        return new UpdatePlayersInboundMessage(
+                localPlayerMovement,
+                null,
+                null,
+                null);
+    }
+
+    /**
+     * Decodes the local player movement update.
+     * 
+     * @param buffer The buffer.
+     * @return The local player movement update.
+     */
+    private LocalPlayerMovementUpdate decodeLocalPlayerMovementUpdate(PacketBuffer buffer) {
+        boolean updateRequired = buffer.getBits(1) == 1;
+
+        // No update required
+        if (!updateRequired) {
+            return null;
+        }
+
+        int movementType = buffer.getBits(2);
+
+        // No movement
+        if (movementType == 0) {
+            return new LocalPlayerMovementUpdate(null, null);
+        }
+        
+        // Walking
+        if (movementType == 1) {
+            int walkDirection = buffer.getBits(3);
+            boolean runUpdateBlock = buffer.getBits(1) == 1;
+
+            return new LocalPlayerMovementUpdate(
+                    new PlayerMovementUpdate(walkDirection, null, runUpdateBlock),
+                    null);
+        }
+
+        // Running
+        if (movementType == 2) {
+            int walkDirection = buffer.getBits(3);
+            int runDirection = buffer.getBits(3);
+            boolean runUpdateBlock = buffer.getBits(1) == 1;
+
+            return new LocalPlayerMovementUpdate(
+                    new PlayerMovementUpdate(walkDirection, runDirection, runUpdateBlock),
+                    null);
+        }
+
+        // Map region changed
+        if (movementType == 3) {
+            boolean teleporting = buffer.getBits(1) == 1;
+            int worldLevel = buffer.getBits(2);
+            boolean runUpdateBlock = buffer.getBits(1) == 1;
+            int localChunkX = buffer.getBits(7);
+            int localChunkY = buffer.getBits(7);
+
+            return new LocalPlayerMovementUpdate(
+                    null,
+                    new LocalPlayerMapRegionChangeUpdate(teleporting, worldLevel, runUpdateBlock, localChunkX,
+                            localChunkY));
+        }
+
+        throw new IllegalStateException("Invalid movement type: " + movementType);
+    }
+
+
+}


### PR DESCRIPTION
Moves the player updating packet (`92`) into the new message pattern.

**Note to reviewer!!!** Click into the first commit, and use `Next` button to go through them in order. They are broken down into logical chunks, with notes in the extended commit message for each commit. I have also added notes saying where you can find the original reference for each function if you want to compare.

Tested:
- appearance
- equipment
- animations
- gfx

![image](https://github.com/runejs/refactored-client-435/assets/2037007/c9f2f344-bd85-4b99-9047-f91d3416e809)
