### PR TITLE
fix: clamp zoom between allowed values

### DIFF
--- a/src/main/java/org/runejs/client/scene/camera/SphericalCamera.java
+++ b/src/main/java/org/runejs/client/scene/camera/SphericalCamera.java
@@ -71,7 +71,7 @@ public class SphericalCamera extends GameCamera {
     }
 
     public void setZoom(int zoom) {
-        this.zoom = zoom;
+        this.zoom = Math.max(150, Math.min(zoom, 1600));
     }
 
     /**


### PR DESCRIPTION
The zoom velocity changes (#153) allowed the user to zoom past the max value, this fixes that issue