### PR TITLE
refactor: document functions in Rasterizer3d, improve some naming

### DIFF
--- a/src/main/java/org/runejs/client/media/Rasterizer3D.java
+++ b/src/main/java/org/runejs/client/media/Rasterizer3D.java
@@ -1241,24 +1241,24 @@ public class Rasterizer3D extends Rasterizer {
         }
     }
 
-    public static void drawShadedTriangle(int y_a, int y_b, int y_c, int x_a, int x_b, int x_c, int z_a, int z_b, int z_c) {
+    public static void drawShadedTriangle(int y_a, int y_b, int y_c, int x_a, int x_b, int x_c, int color_a, int color_b, int color_c) {
         int x_a_off = 0;
         int z_a_off = 0;
         if(y_b != y_a) {
             x_a_off = (x_b - x_a << 16) / (y_b - y_a);
-            z_a_off = (z_b - z_a << 15) / (y_b - y_a);
+            z_a_off = (color_b - color_a << 15) / (y_b - y_a);
         }
         int x_b_off = 0;
         int z_b_off = 0;
         if(y_c != y_b) {
             x_b_off = (x_c - x_b << 16) / (y_c - y_b);
-            z_b_off = (z_c - z_b << 15) / (y_c - y_b);
+            z_b_off = (color_c - color_b << 15) / (y_c - y_b);
         }
         int x_c_off = 0;
         int z_c_off = 0;
         if(y_c != y_a) {
             x_c_off = (x_a - x_c << 16) / (y_a - y_c);
-            z_c_off = (z_a - z_c << 15) / (y_a - y_c);
+            z_c_off = (color_a - color_c << 15) / (y_a - y_c);
         }
         if(y_a <= y_b && y_a <= y_c) {
             if(y_a >= bottomY) {
@@ -1272,19 +1272,19 @@ public class Rasterizer3D extends Rasterizer {
             }
             if(y_b < y_c) {
                 x_c = x_a <<= 16;
-                z_c = z_a <<= 15;
+                color_c = color_a <<= 15;
                 if(y_a < 0) {
                     x_c -= x_c_off * y_a;
                     x_a -= x_a_off * y_a;
-                    z_c -= z_c_off * y_a;
-                    z_a -= z_a_off * y_a;
+                    color_c -= z_c_off * y_a;
+                    color_a -= z_a_off * y_a;
                     y_a = 0;
                 }
                 x_b <<= 16;
-                z_b <<= 15;
+                color_b <<= 15;
                 if(y_b < 0) {
                     x_b -= x_b_off * y_b;
-                    z_b -= z_b_off * y_b;
+                    color_b -= z_b_off * y_b;
                     y_b = 0;
                 }
                 if(y_a != y_b && x_c_off < x_a_off || y_a == y_b && x_c_off > x_b_off) {
@@ -1292,19 +1292,19 @@ public class Rasterizer3D extends Rasterizer {
                     y_b -= y_a;
                     y_a = lineOffsets[y_a];
                     while(--y_b >= 0) {
-                        drawShadedLine(Rasterizer.destinationPixels, y_a, x_c >> 16, x_a >> 16, z_c >> 7, z_a >> 7);
+                        drawShadedLine(Rasterizer.destinationPixels, y_a, x_c >> 16, x_a >> 16, color_c >> 7, color_a >> 7);
                         x_c += x_c_off;
                         x_a += x_a_off;
-                        z_c += z_c_off;
-                        z_a += z_a_off;
+                        color_c += z_c_off;
+                        color_a += z_a_off;
                         y_a += Rasterizer.destinationWidth;
                     }
                     while(--y_c >= 0) {
-                        drawShadedLine(Rasterizer.destinationPixels, y_a, x_c >> 16, x_b >> 16, z_c >> 7, z_b >> 7);
+                        drawShadedLine(Rasterizer.destinationPixels, y_a, x_c >> 16, x_b >> 16, color_c >> 7, color_b >> 7);
                         x_c += x_c_off;
                         x_b += x_b_off;
-                        z_c += z_c_off;
-                        z_b += z_b_off;
+                        color_c += z_c_off;
+                        color_b += z_b_off;
                         y_a += Rasterizer.destinationWidth;
                     }
                 } else {
@@ -1312,37 +1312,37 @@ public class Rasterizer3D extends Rasterizer {
                     y_b -= y_a;
                     y_a = lineOffsets[y_a];
                     while(--y_b >= 0) {
-                        drawShadedLine(Rasterizer.destinationPixels, y_a, x_a >> 16, x_c >> 16, z_a >> 7, z_c >> 7);
+                        drawShadedLine(Rasterizer.destinationPixels, y_a, x_a >> 16, x_c >> 16, color_a >> 7, color_c >> 7);
                         x_c += x_c_off;
                         x_a += x_a_off;
-                        z_c += z_c_off;
-                        z_a += z_a_off;
+                        color_c += z_c_off;
+                        color_a += z_a_off;
                         y_a += Rasterizer.destinationWidth;
                     }
                     while(--y_c >= 0) {
-                        drawShadedLine(Rasterizer.destinationPixels, y_a, x_b >> 16, x_c >> 16, z_b >> 7, z_c >> 7);
+                        drawShadedLine(Rasterizer.destinationPixels, y_a, x_b >> 16, x_c >> 16, color_b >> 7, color_c >> 7);
                         x_c += x_c_off;
                         x_b += x_b_off;
-                        z_c += z_c_off;
-                        z_b += z_b_off;
+                        color_c += z_c_off;
+                        color_b += z_b_off;
                         y_a += Rasterizer.destinationWidth;
                     }
                 }
             } else {
                 x_b = x_a <<= 16;
-                z_b = z_a <<= 15;
+                color_b = color_a <<= 15;
                 if(y_a < 0) {
                     x_b -= x_c_off * y_a;
                     x_a -= x_a_off * y_a;
-                    z_b -= z_c_off * y_a;
-                    z_a -= z_a_off * y_a;
+                    color_b -= z_c_off * y_a;
+                    color_a -= z_a_off * y_a;
                     y_a = 0;
                 }
                 x_c <<= 16;
-                z_c <<= 15;
+                color_c <<= 15;
                 if(y_c < 0) {
                     x_c -= x_b_off * y_c;
-                    z_c -= z_b_off * y_c;
+                    color_c -= z_b_off * y_c;
                     y_c = 0;
                 }
                 if(y_a != y_c && x_c_off < x_a_off || y_a == y_c && x_b_off > x_a_off) {
@@ -1350,19 +1350,19 @@ public class Rasterizer3D extends Rasterizer {
                     y_c -= y_a;
                     y_a = lineOffsets[y_a];
                     while(--y_c >= 0) {
-                        drawShadedLine(Rasterizer.destinationPixels, y_a, x_b >> 16, x_a >> 16, z_b >> 7, z_a >> 7);
+                        drawShadedLine(Rasterizer.destinationPixels, y_a, x_b >> 16, x_a >> 16, color_b >> 7, color_a >> 7);
                         x_b += x_c_off;
                         x_a += x_a_off;
-                        z_b += z_c_off;
-                        z_a += z_a_off;
+                        color_b += z_c_off;
+                        color_a += z_a_off;
                         y_a += Rasterizer.destinationWidth;
                     }
                     while(--y_b >= 0) {
-                        drawShadedLine(Rasterizer.destinationPixels, y_a, x_c >> 16, x_a >> 16, z_c >> 7, z_a >> 7);
+                        drawShadedLine(Rasterizer.destinationPixels, y_a, x_c >> 16, x_a >> 16, color_c >> 7, color_a >> 7);
                         x_c += x_b_off;
                         x_a += x_a_off;
-                        z_c += z_b_off;
-                        z_a += z_a_off;
+                        color_c += z_b_off;
+                        color_a += z_a_off;
                         y_a += Rasterizer.destinationWidth;
                     }
                 } else {
@@ -1370,19 +1370,19 @@ public class Rasterizer3D extends Rasterizer {
                     y_c -= y_a;
                     y_a = lineOffsets[y_a];
                     while(--y_c >= 0) {
-                        drawShadedLine(Rasterizer.destinationPixels, y_a, x_a >> 16, x_b >> 16, z_a >> 7, z_b >> 7);
+                        drawShadedLine(Rasterizer.destinationPixels, y_a, x_a >> 16, x_b >> 16, color_a >> 7, color_b >> 7);
                         x_b += x_c_off;
                         x_a += x_a_off;
-                        z_b += z_c_off;
-                        z_a += z_a_off;
+                        color_b += z_c_off;
+                        color_a += z_a_off;
                         y_a += Rasterizer.destinationWidth;
                     }
                     while(--y_b >= 0) {
-                        drawShadedLine(Rasterizer.destinationPixels, y_a, x_a >> 16, x_c >> 16, z_a >> 7, z_c >> 7);
+                        drawShadedLine(Rasterizer.destinationPixels, y_a, x_a >> 16, x_c >> 16, color_a >> 7, color_c >> 7);
                         x_c += x_b_off;
                         x_a += x_a_off;
-                        z_c += z_b_off;
-                        z_a += z_a_off;
+                        color_c += z_b_off;
+                        color_a += z_a_off;
                         y_a += Rasterizer.destinationWidth;
                     }
                 }
@@ -1398,19 +1398,19 @@ public class Rasterizer3D extends Rasterizer {
                     }
                     if(y_c < y_a) {
                         x_a = x_b <<= 16;
-                        z_a = z_b <<= 15;
+                        color_a = color_b <<= 15;
                         if(y_b < 0) {
                             x_a -= x_a_off * y_b;
                             x_b -= x_b_off * y_b;
-                            z_a -= z_a_off * y_b;
-                            z_b -= z_b_off * y_b;
+                            color_a -= z_a_off * y_b;
+                            color_b -= z_b_off * y_b;
                             y_b = 0;
                         }
                         x_c <<= 16;
-                        z_c <<= 15;
+                        color_c <<= 15;
                         if(y_c < 0) {
                             x_c -= x_c_off * y_c;
-                            z_c -= z_c_off * y_c;
+                            color_c -= z_c_off * y_c;
                             y_c = 0;
                         }
                         if(y_b != y_c && x_a_off < x_b_off || y_b == y_c && x_a_off > x_c_off) {
@@ -1418,19 +1418,19 @@ public class Rasterizer3D extends Rasterizer {
                             y_c -= y_b;
                             y_b = lineOffsets[y_b];
                             while(--y_c >= 0) {
-                                drawShadedLine(Rasterizer.destinationPixels, y_b, x_a >> 16, x_b >> 16, z_a >> 7, z_b >> 7);
+                                drawShadedLine(Rasterizer.destinationPixels, y_b, x_a >> 16, x_b >> 16, color_a >> 7, color_b >> 7);
                                 x_a += x_a_off;
                                 x_b += x_b_off;
-                                z_a += z_a_off;
-                                z_b += z_b_off;
+                                color_a += z_a_off;
+                                color_b += z_b_off;
                                 y_b += Rasterizer.destinationWidth;
                             }
                             while(--y_a >= 0) {
-                                drawShadedLine(Rasterizer.destinationPixels, y_b, x_a >> 16, x_c >> 16, z_a >> 7, z_c >> 7);
+                                drawShadedLine(Rasterizer.destinationPixels, y_b, x_a >> 16, x_c >> 16, color_a >> 7, color_c >> 7);
                                 x_a += x_a_off;
                                 x_c += x_c_off;
-                                z_a += z_a_off;
-                                z_c += z_c_off;
+                                color_a += z_a_off;
+                                color_c += z_c_off;
                                 y_b += Rasterizer.destinationWidth;
                             }
                         } else {
@@ -1438,37 +1438,37 @@ public class Rasterizer3D extends Rasterizer {
                             y_c -= y_b;
                             y_b = lineOffsets[y_b];
                             while(--y_c >= 0) {
-                                drawShadedLine(Rasterizer.destinationPixels, y_b, x_b >> 16, x_a >> 16, z_b >> 7, z_a >> 7);
+                                drawShadedLine(Rasterizer.destinationPixels, y_b, x_b >> 16, x_a >> 16, color_b >> 7, color_a >> 7);
                                 x_a += x_a_off;
                                 x_b += x_b_off;
-                                z_a += z_a_off;
-                                z_b += z_b_off;
+                                color_a += z_a_off;
+                                color_b += z_b_off;
                                 y_b += Rasterizer.destinationWidth;
                             }
                             while(--y_a >= 0) {
-                                drawShadedLine(Rasterizer.destinationPixels, y_b, x_c >> 16, x_a >> 16, z_c >> 7, z_a >> 7);
+                                drawShadedLine(Rasterizer.destinationPixels, y_b, x_c >> 16, x_a >> 16, color_c >> 7, color_a >> 7);
                                 x_a += x_a_off;
                                 x_c += x_c_off;
-                                z_a += z_a_off;
-                                z_c += z_c_off;
+                                color_a += z_a_off;
+                                color_c += z_c_off;
                                 y_b += Rasterizer.destinationWidth;
                             }
                         }
                     } else {
                         x_c = x_b <<= 16;
-                        z_c = z_b <<= 15;
+                        color_c = color_b <<= 15;
                         if(y_b < 0) {
                             x_c -= x_a_off * y_b;
                             x_b -= x_b_off * y_b;
-                            z_c -= z_a_off * y_b;
-                            z_b -= z_b_off * y_b;
+                            color_c -= z_a_off * y_b;
+                            color_b -= z_b_off * y_b;
                             y_b = 0;
                         }
                         x_a <<= 16;
-                        z_a <<= 15;
+                        color_a <<= 15;
                         if(y_a < 0) {
                             x_a -= x_c_off * y_a;
-                            z_a -= z_c_off * y_a;
+                            color_a -= z_c_off * y_a;
                             y_a = 0;
                         }
                         if(x_a_off < x_b_off) {
@@ -1476,19 +1476,19 @@ public class Rasterizer3D extends Rasterizer {
                             y_a -= y_b;
                             y_b = lineOffsets[y_b];
                             while(--y_a >= 0) {
-                                drawShadedLine(Rasterizer.destinationPixels, y_b, x_c >> 16, x_b >> 16, z_c >> 7, z_b >> 7);
+                                drawShadedLine(Rasterizer.destinationPixels, y_b, x_c >> 16, x_b >> 16, color_c >> 7, color_b >> 7);
                                 x_c += x_a_off;
                                 x_b += x_b_off;
-                                z_c += z_a_off;
-                                z_b += z_b_off;
+                                color_c += z_a_off;
+                                color_b += z_b_off;
                                 y_b += Rasterizer.destinationWidth;
                             }
                             while(--y_c >= 0) {
-                                drawShadedLine(Rasterizer.destinationPixels, y_b, x_a >> 16, x_b >> 16, z_a >> 7, z_b >> 7);
+                                drawShadedLine(Rasterizer.destinationPixels, y_b, x_a >> 16, x_b >> 16, color_a >> 7, color_b >> 7);
                                 x_a += x_c_off;
                                 x_b += x_b_off;
-                                z_a += z_c_off;
-                                z_b += z_b_off;
+                                color_a += z_c_off;
+                                color_b += z_b_off;
                                 y_b += Rasterizer.destinationWidth;
                             }
                         } else {
@@ -1496,19 +1496,19 @@ public class Rasterizer3D extends Rasterizer {
                             y_a -= y_b;
                             y_b = lineOffsets[y_b];
                             while(--y_a >= 0) {
-                                drawShadedLine(Rasterizer.destinationPixels, y_b, x_b >> 16, x_c >> 16, z_b >> 7, z_c >> 7);
+                                drawShadedLine(Rasterizer.destinationPixels, y_b, x_b >> 16, x_c >> 16, color_b >> 7, color_c >> 7);
                                 x_c += x_a_off;
                                 x_b += x_b_off;
-                                z_c += z_a_off;
-                                z_b += z_b_off;
+                                color_c += z_a_off;
+                                color_b += z_b_off;
                                 y_b += Rasterizer.destinationWidth;
                             }
                             while(--y_c >= 0) {
-                                drawShadedLine(Rasterizer.destinationPixels, y_b, x_b >> 16, x_a >> 16, z_b >> 7, z_a >> 7);
+                                drawShadedLine(Rasterizer.destinationPixels, y_b, x_b >> 16, x_a >> 16, color_b >> 7, color_a >> 7);
                                 x_a += x_c_off;
                                 x_b += x_b_off;
-                                z_a += z_c_off;
-                                z_b += z_b_off;
+                                color_a += z_c_off;
+                                color_b += z_b_off;
                                 y_b += Rasterizer.destinationWidth;
                             }
                         }
@@ -1523,19 +1523,19 @@ public class Rasterizer3D extends Rasterizer {
                 }
                 if(y_a < y_b) {
                     x_b = x_c <<= 16;
-                    z_b = z_c <<= 15;
+                    color_b = color_c <<= 15;
                     if(y_c < 0) {
                         x_b -= x_b_off * y_c;
                         x_c -= x_c_off * y_c;
-                        z_b -= z_b_off * y_c;
-                        z_c -= z_c_off * y_c;
+                        color_b -= z_b_off * y_c;
+                        color_c -= z_c_off * y_c;
                         y_c = 0;
                     }
                     x_a <<= 16;
-                    z_a <<= 15;
+                    color_a <<= 15;
                     if(y_a < 0) {
                         x_a -= x_a_off * y_a;
-                        z_a -= z_a_off * y_a;
+                        color_a -= z_a_off * y_a;
                         y_a = 0;
                     }
                     if(x_b_off < x_c_off) {
@@ -1543,19 +1543,19 @@ public class Rasterizer3D extends Rasterizer {
                         y_a -= y_c;
                         y_c = lineOffsets[y_c];
                         while(--y_a >= 0) {
-                            drawShadedLine(Rasterizer.destinationPixels, y_c, x_b >> 16, x_c >> 16, z_b >> 7, z_c >> 7);
+                            drawShadedLine(Rasterizer.destinationPixels, y_c, x_b >> 16, x_c >> 16, color_b >> 7, color_c >> 7);
                             x_b += x_b_off;
                             x_c += x_c_off;
-                            z_b += z_b_off;
-                            z_c += z_c_off;
+                            color_b += z_b_off;
+                            color_c += z_c_off;
                             y_c += Rasterizer.destinationWidth;
                         }
                         while(--y_b >= 0) {
-                            drawShadedLine(Rasterizer.destinationPixels, y_c, x_b >> 16, x_a >> 16, z_b >> 7, z_a >> 7);
+                            drawShadedLine(Rasterizer.destinationPixels, y_c, x_b >> 16, x_a >> 16, color_b >> 7, color_a >> 7);
                             x_b += x_b_off;
                             x_a += x_a_off;
-                            z_b += z_b_off;
-                            z_a += z_a_off;
+                            color_b += z_b_off;
+                            color_a += z_a_off;
                             y_c += Rasterizer.destinationWidth;
                         }
                     } else {
@@ -1563,37 +1563,37 @@ public class Rasterizer3D extends Rasterizer {
                         y_a -= y_c;
                         y_c = lineOffsets[y_c];
                         while(--y_a >= 0) {
-                            drawShadedLine(Rasterizer.destinationPixels, y_c, x_c >> 16, x_b >> 16, z_c >> 7, z_b >> 7);
+                            drawShadedLine(Rasterizer.destinationPixels, y_c, x_c >> 16, x_b >> 16, color_c >> 7, color_b >> 7);
                             x_b += x_b_off;
                             x_c += x_c_off;
-                            z_b += z_b_off;
-                            z_c += z_c_off;
+                            color_b += z_b_off;
+                            color_c += z_c_off;
                             y_c += Rasterizer.destinationWidth;
                         }
                         while(--y_b >= 0) {
-                            drawShadedLine(Rasterizer.destinationPixels, y_c, x_a >> 16, x_b >> 16, z_a >> 7, z_b >> 7);
+                            drawShadedLine(Rasterizer.destinationPixels, y_c, x_a >> 16, x_b >> 16, color_a >> 7, color_b >> 7);
                             x_b += x_b_off;
                             x_a += x_a_off;
-                            z_b += z_b_off;
-                            z_a += z_a_off;
+                            color_b += z_b_off;
+                            color_a += z_a_off;
                             y_c += Rasterizer.destinationWidth;
                         }
                     }
                 } else {
                     x_a = x_c <<= 16;
-                    z_a = z_c <<= 15;
+                    color_a = color_c <<= 15;
                     if(y_c < 0) {
                         x_a -= x_b_off * y_c;
                         x_c -= x_c_off * y_c;
-                        z_a -= z_b_off * y_c;
-                        z_c -= z_c_off * y_c;
+                        color_a -= z_b_off * y_c;
+                        color_c -= z_c_off * y_c;
                         y_c = 0;
                     }
                     x_b <<= 16;
-                    z_b <<= 15;
+                    color_b <<= 15;
                     if(y_b < 0) {
                         x_b -= x_a_off * y_b;
-                        z_b -= z_a_off * y_b;
+                        color_b -= z_a_off * y_b;
                         y_b = 0;
                     }
                     if(x_b_off < x_c_off) {
@@ -1601,19 +1601,19 @@ public class Rasterizer3D extends Rasterizer {
                         y_b -= y_c;
                         y_c = lineOffsets[y_c];
                         while(--y_b >= 0) {
-                            drawShadedLine(Rasterizer.destinationPixels, y_c, x_a >> 16, x_c >> 16, z_a >> 7, z_c >> 7);
+                            drawShadedLine(Rasterizer.destinationPixels, y_c, x_a >> 16, x_c >> 16, color_a >> 7, color_c >> 7);
                             x_a += x_b_off;
                             x_c += x_c_off;
-                            z_a += z_b_off;
-                            z_c += z_c_off;
+                            color_a += z_b_off;
+                            color_c += z_c_off;
                             y_c += Rasterizer.destinationWidth;
                         }
                         while(--y_a >= 0) {
-                            drawShadedLine(Rasterizer.destinationPixels, y_c, x_b >> 16, x_c >> 16, z_b >> 7, z_c >> 7);
+                            drawShadedLine(Rasterizer.destinationPixels, y_c, x_b >> 16, x_c >> 16, color_b >> 7, color_c >> 7);
                             x_b += x_a_off;
                             x_c += x_c_off;
-                            z_b += z_a_off;
-                            z_c += z_c_off;
+                            color_b += z_a_off;
+                            color_c += z_c_off;
                             y_c += Rasterizer.destinationWidth;
                         }
                     } else {
@@ -1621,19 +1621,19 @@ public class Rasterizer3D extends Rasterizer {
                         y_b -= y_c;
                         y_c = lineOffsets[y_c];
                         while(--y_b >= 0) {
-                            drawShadedLine(Rasterizer.destinationPixels, y_c, x_c >> 16, x_a >> 16, z_c >> 7, z_a >> 7);
+                            drawShadedLine(Rasterizer.destinationPixels, y_c, x_c >> 16, x_a >> 16, color_c >> 7, color_a >> 7);
                             x_a += x_b_off;
                             x_c += x_c_off;
-                            z_a += z_b_off;
-                            z_c += z_c_off;
+                            color_a += z_b_off;
+                            color_c += z_c_off;
                             y_c += Rasterizer.destinationWidth;
                         }
                         while(--y_a >= 0) {
-                            drawShadedLine(Rasterizer.destinationPixels, y_c, x_c >> 16, x_b >> 16, z_c >> 7, z_b >> 7);
+                            drawShadedLine(Rasterizer.destinationPixels, y_c, x_c >> 16, x_b >> 16, color_c >> 7, color_b >> 7);
                             x_b += x_a_off;
                             x_c += x_c_off;
-                            z_b += z_a_off;
-                            z_c += z_c_off;
+                            color_b += z_a_off;
+                            color_c += z_c_off;
                             y_c += Rasterizer.destinationWidth;
                         }
                     }

--- a/src/main/java/org/runejs/client/scene/SceneRenderer.java
+++ b/src/main/java/org/runejs/client/scene/SceneRenderer.java
@@ -791,47 +791,42 @@ public class SceneRenderer {
         int zC = this.scene.landscape.tile_height[arg1][tileX + 1][tileY + 1] - currentCamera.getPosition().z;
         int zD = this.scene.landscape.tile_height[arg1][tileX][tileY + 1] - currentCamera.getPosition().z;
 
-        int sinX = currentCamera.getRotation().yawSine;
-        int cosineX = currentCamera.getRotation().yawCosine;
-        int sinY = currentCamera.getRotation().pitchSine;
-        int cosineY = currentCamera.getRotation().pitchCosine;
+        int[] resultA = Util3d.getProjectedPoint(currentCamera, xA, yA, zA);
+        if (resultA == null) {
+            return;
+        }
 
-        int temp = yA * sinX + xA * cosineX >> 16;
-        yA = yA * cosineX - xA * sinX >> 16;
-        xA = temp;
-        temp = zA * cosineY - yA * sinY >> 16;
-        yA = zA * sinY + yA * cosineY >> 16;
-        zA = temp;
-        if (yA < 50) {
+        xA = resultA[0];
+        yA = resultA[1];
+        zA = resultA[2];
+
+        int[] resultB = Util3d.getProjectedPoint(currentCamera, xB, yB, zB);
+        if (resultB == null) {
             return;
         }
-        temp = yB * sinX + xB * cosineX >> 16;
-        yB = yB * cosineX - xB * sinX >> 16;
-        xB = temp;
-        temp = zB * cosineY - yB * sinY >> 16;
-        yB = zB * sinY + yB * cosineY >> 16;
-        zB = temp;
-        if (yB < 50) {
+
+        xB = resultB[0];
+        yB = resultB[1];
+        zB = resultB[2];
+
+        int[] resultD = Util3d.getProjectedPoint(currentCamera, xD, yD, zC);
+        if (resultD == null) {
             return;
         }
-        temp = yD * sinX + xD * cosineX >> 16;
-        yD = yD * cosineX - xD * sinX >> 16;
-        xD = temp;
-        temp = zC * cosineY - yD * sinY >> 16;
-        yD = zC * sinY + yD * cosineY >> 16;
-        zC = temp;
-        if (yD < 50) {
+
+        xD = resultD[0];
+        yD = resultD[1];
+        zC = resultD[2];
+
+        int[] resultC = Util3d.getProjectedPoint(currentCamera, xC, yC, zD);
+        if (resultC == null) {
             return;
         }
-        temp = yC * sinX + xC * cosineX >> 16;
-        yC = yC * cosineX - xC * sinX >> 16;
-        xC = temp;
-        temp = zD * cosineY - yC * sinY >> 16;
-        yC = zD * sinY + yC * cosineY >> 16;
-        zD = temp;
-        if (yC < 50) {
-            return;
-        }
+
+        xC = resultC[0];
+        yC = resultC[1];
+        zD = resultC[2];
+
         int screenXA = Rasterizer3D.center_x + (xA << 9) / yA;
         int screenYA = Rasterizer3D.center_y + (zA << 9) / yA;
         int screenXB = Rasterizer3D.center_x + (xB << 9) / yB;

--- a/src/main/java/org/runejs/client/scene/SceneRenderer.java
+++ b/src/main/java/org/runejs/client/scene/SceneRenderer.java
@@ -777,7 +777,7 @@ public class SceneRenderer {
         }
     }
 
-    private void renderPlainTile(GenericTile plainTile, int arg1, int tileX, int tileY) {
+    private void renderPlainTile(GenericTile plainTile, int plane, int tileX, int tileY) {
         int nwX;
         int swX = nwX = (tileX << 7) - currentCamera.getPosition().x;
         int seY;
@@ -786,10 +786,10 @@ public class SceneRenderer {
         int seX = neX = swX + 128;
         int nwY;
         int neY = nwY = swY + 128;
-        int swZ = this.scene.landscape.tile_height[arg1][tileX][tileY] - currentCamera.getPosition().z;
-        int seZ = this.scene.landscape.tile_height[arg1][tileX + 1][tileY] - currentCamera.getPosition().z;
-        int neZ = this.scene.landscape.tile_height[arg1][tileX + 1][tileY + 1] - currentCamera.getPosition().z;
-        int nwZ = this.scene.landscape.tile_height[arg1][tileX][tileY + 1] - currentCamera.getPosition().z;
+        int swZ = this.scene.landscape.tile_height[plane][tileX][tileY] - currentCamera.getPosition().z;
+        int seZ = this.scene.landscape.tile_height[plane][tileX + 1][tileY] - currentCamera.getPosition().z;
+        int neZ = this.scene.landscape.tile_height[plane][tileX + 1][tileY + 1] - currentCamera.getPosition().z;
+        int nwZ = this.scene.landscape.tile_height[plane][tileX][tileY + 1] - currentCamera.getPosition().z;
 
         int[] resultA = Util3d.getProjectedPoint(currentCamera, swX, swY, swZ);
         if (resultA == null) {
@@ -847,16 +847,16 @@ public class SceneRenderer {
                 this.scene.hoveredTileY = tileY;
             }
             if (plainTile.texture == -1) {
-                if (plainTile.colourD != 12345678) {
-                    Rasterizer3D.drawShadedTriangle(screenYNE, screenYNW, screenYSE, screenXNE, screenXNW, screenXSE, plainTile.colourD, plainTile.colourC, plainTile.colourB);
+                if (plainTile.colourNE != 12345678) {
+                    Rasterizer3D.drawShadedTriangle(screenYNE, screenYNW, screenYSE, screenXNE, screenXNW, screenXSE, plainTile.colourNE, plainTile.colourNW, plainTile.colourSE);
                 }
             } else if (Scene.lowMemory) {
                 int rgb = Rasterizer3D.interface3.getAverageTextureColour(plainTile.texture);
-                Rasterizer3D.drawShadedTriangle(screenYNE, screenYNW, screenYSE, screenXNE, screenXNW, screenXSE, Scene.adjustLightness(rgb, plainTile.colourD), Scene.adjustLightness(rgb, plainTile.colourC), Scene.adjustLightness(rgb, plainTile.colourB));
+                Rasterizer3D.drawShadedTriangle(screenYNE, screenYNW, screenYSE, screenXNE, screenXNW, screenXSE, Scene.adjustLightness(rgb, plainTile.colourNE), Scene.adjustLightness(rgb, plainTile.colourNW), Scene.adjustLightness(rgb, plainTile.colourSE));
             } else if (plainTile.flat) {
-                Rasterizer3D.drawTexturedTriangle(screenYNE, screenYNW, screenYSE, screenXNE, screenXNW, screenXSE, plainTile.colourD, plainTile.colourC, plainTile.colourB, swX, seX, nwX, swZ, seZ, nwZ, swY, seY, nwY, plainTile.texture);
+                Rasterizer3D.drawTexturedTriangle(screenYNE, screenYNW, screenYSE, screenXNE, screenXNW, screenXSE, plainTile.colourNE, plainTile.colourNW, plainTile.colourSE, swX, seX, nwX, swZ, seZ, nwZ, swY, seY, nwY, plainTile.texture);
             } else {
-                Rasterizer3D.drawTexturedTriangle(screenYNE, screenYNW, screenYSE, screenXNE, screenXNW, screenXSE, plainTile.colourD, plainTile.colourC, plainTile.colourB, neX, nwX, seX, neZ, nwZ, seZ, neY, nwY, seY, plainTile.texture);
+                Rasterizer3D.drawTexturedTriangle(screenYNE, screenYNW, screenYSE, screenXNE, screenXNW, screenXSE, plainTile.colourNE, plainTile.colourNW, plainTile.colourSE, neX, nwX, seX, neZ, nwZ, seZ, neY, nwY, seY, plainTile.texture);
             }
         }
         if ((screenXSW - screenXSE) * (screenYNW - screenYSE) - (screenYSW - screenYSE) * (screenXNW - screenXSE) > 0) {
@@ -871,14 +871,14 @@ public class SceneRenderer {
                 this.scene.hoveredTileY = tileY;
             }
             if (plainTile.texture == -1) {
-                if (plainTile.colourA != 12345678) {
-                    Rasterizer3D.drawShadedTriangle(screenYSW, screenYSE, screenYNW, screenXSW, screenXSE, screenXNW, plainTile.colourA, plainTile.colourB, plainTile.colourC);
+                if (plainTile.colourSW != 12345678) {
+                    Rasterizer3D.drawShadedTriangle(screenYSW, screenYSE, screenYNW, screenXSW, screenXSE, screenXNW, plainTile.colourSW, plainTile.colourSE, plainTile.colourNW);
                 }
             } else if (Scene.lowMemory) {
                 int i_209_ = Rasterizer3D.interface3.getAverageTextureColour(plainTile.texture);
-                Rasterizer3D.drawShadedTriangle(screenYSW, screenYSE, screenYNW, screenXSW, screenXSE, screenXNW, Scene.adjustLightness(i_209_, plainTile.colourA), Scene.adjustLightness(i_209_, plainTile.colourB), Scene.adjustLightness(i_209_, plainTile.colourC));
+                Rasterizer3D.drawShadedTriangle(screenYSW, screenYSE, screenYNW, screenXSW, screenXSE, screenXNW, Scene.adjustLightness(i_209_, plainTile.colourSW), Scene.adjustLightness(i_209_, plainTile.colourSE), Scene.adjustLightness(i_209_, plainTile.colourNW));
             } else {
-                Rasterizer3D.drawTexturedTriangle(screenYSW, screenYSE, screenYNW, screenXSW, screenXSE, screenXNW, plainTile.colourA, plainTile.colourB, plainTile.colourC, swX, seX, nwX, swZ, seZ, nwZ, swY, seY, nwY, plainTile.texture);
+                Rasterizer3D.drawTexturedTriangle(screenYSW, screenYSE, screenYNW, screenXSW, screenXSE, screenXNW, plainTile.colourSW, plainTile.colourSE, plainTile.colourNW, swX, seX, nwX, swZ, seZ, nwZ, swY, seY, nwY, plainTile.texture);
             }
         }
     }

--- a/src/main/java/org/runejs/client/scene/SceneRenderer.java
+++ b/src/main/java/org/runejs/client/scene/SceneRenderer.java
@@ -778,107 +778,107 @@ public class SceneRenderer {
     }
 
     private void renderPlainTile(GenericTile plainTile, int arg1, int tileX, int tileY) {
-        int xC;
-        int xA = xC = (tileX << 7) - currentCamera.getPosition().x;
-        int yB;
-        int yA = yB = (tileY << 7) - currentCamera.getPosition().y;
-        int xD;
-        int xB = xD = xA + 128;
-        int yC;
-        int yD = yC = yA + 128;
-        int zA = this.scene.landscape.tile_height[arg1][tileX][tileY] - currentCamera.getPosition().z;
-        int zB = this.scene.landscape.tile_height[arg1][tileX + 1][tileY] - currentCamera.getPosition().z;
-        int zC = this.scene.landscape.tile_height[arg1][tileX + 1][tileY + 1] - currentCamera.getPosition().z;
-        int zD = this.scene.landscape.tile_height[arg1][tileX][tileY + 1] - currentCamera.getPosition().z;
+        int nwX;
+        int swX = nwX = (tileX << 7) - currentCamera.getPosition().x;
+        int seY;
+        int swY = seY = (tileY << 7) - currentCamera.getPosition().y;
+        int neX;
+        int seX = neX = swX + 128;
+        int nwY;
+        int neY = nwY = swY + 128;
+        int swZ = this.scene.landscape.tile_height[arg1][tileX][tileY] - currentCamera.getPosition().z;
+        int seZ = this.scene.landscape.tile_height[arg1][tileX + 1][tileY] - currentCamera.getPosition().z;
+        int neZ = this.scene.landscape.tile_height[arg1][tileX + 1][tileY + 1] - currentCamera.getPosition().z;
+        int nwZ = this.scene.landscape.tile_height[arg1][tileX][tileY + 1] - currentCamera.getPosition().z;
 
-        int[] resultA = Util3d.getProjectedPoint(currentCamera, xA, yA, zA);
+        int[] resultA = Util3d.getProjectedPoint(currentCamera, swX, swY, swZ);
         if (resultA == null) {
             return;
         }
 
-        xA = resultA[0];
-        yA = resultA[1];
-        zA = resultA[2];
+        swX = resultA[0];
+        swY = resultA[1];
+        swZ = resultA[2];
 
-        int[] resultB = Util3d.getProjectedPoint(currentCamera, xB, yB, zB);
+        int[] resultB = Util3d.getProjectedPoint(currentCamera, seX, seY, seZ);
         if (resultB == null) {
             return;
         }
 
-        xB = resultB[0];
-        yB = resultB[1];
-        zB = resultB[2];
+        seX = resultB[0];
+        seY = resultB[1];
+        seZ = resultB[2];
 
-        int[] resultD = Util3d.getProjectedPoint(currentCamera, xD, yD, zC);
-        if (resultD == null) {
+        int[] resultNE = Util3d.getProjectedPoint(currentCamera, neX, neY, neZ);
+        if (resultNE == null) {
             return;
         }
 
-        xD = resultD[0];
-        yD = resultD[1];
-        zC = resultD[2];
+        neX = resultNE[0];
+        neY = resultNE[1];
+        neZ = resultNE[2];
 
-        int[] resultC = Util3d.getProjectedPoint(currentCamera, xC, yC, zD);
+        int[] resultC = Util3d.getProjectedPoint(currentCamera, nwX, nwY, nwZ);
         if (resultC == null) {
             return;
         }
 
-        xC = resultC[0];
-        yC = resultC[1];
-        zD = resultC[2];
+        nwX = resultC[0];
+        nwY = resultC[1];
+        nwZ = resultC[2];
 
-        int screenXA = Rasterizer3D.center_x + (xA << 9) / yA;
-        int screenYA = Rasterizer3D.center_y + (zA << 9) / yA;
-        int screenXB = Rasterizer3D.center_x + (xB << 9) / yB;
-        int screenYB = Rasterizer3D.center_y + (zB << 9) / yB;
-        int screenXD = Rasterizer3D.center_x + (xD << 9) / yD;
-        int screenYD = Rasterizer3D.center_y + (zC << 9) / yD;
-        int screenXC = Rasterizer3D.center_x + (xC << 9) / yC;
-        int screenYC = Rasterizer3D.center_y + (zD << 9) / yC;
+        int screenXSW = Rasterizer3D.center_x + (swX << 9) / swY;
+        int screenYSW = Rasterizer3D.center_y + (swZ << 9) / swY;
+        int screenXSE = Rasterizer3D.center_x + (seX << 9) / seY;
+        int screenYSE = Rasterizer3D.center_y + (seZ << 9) / seY;
+        int screenXNE = Rasterizer3D.center_x + (neX << 9) / neY;
+        int screenYNE = Rasterizer3D.center_y + (neZ << 9) / neY;
+        int screenXNW = Rasterizer3D.center_x + (nwX << 9) / nwY;
+        int screenYNW = Rasterizer3D.center_y + (nwZ << 9) / nwY;
         Rasterizer3D.alpha = 0;
-        if ((screenXD - screenXC) * (screenYB - screenYC) - (screenYD - screenYC) * (screenXB - screenXC) > 0) {
-            Rasterizer3D.restrict_edges = screenXD < 0 || screenXC < 0 || screenXB < 0 || screenXD > Rasterizer3D.viewportRx || screenXC > Rasterizer3D.viewportRx || screenXB > Rasterizer3D.viewportRx;
-            if (this.scene.clicked && isMouseWithinTriangle(this.scene.clickX, this.scene.clickY, screenYD, screenYC, screenYB, screenXD, screenXC, screenXB)) {
+        if ((screenXNE - screenXNW) * (screenYSE - screenYNW) - (screenYNE - screenYNW) * (screenXSE - screenXNW) > 0) {
+            Rasterizer3D.restrict_edges = screenXNE < 0 || screenXNW < 0 || screenXSE < 0 || screenXNE > Rasterizer3D.viewportRx || screenXNW > Rasterizer3D.viewportRx || screenXSE > Rasterizer3D.viewportRx;
+            if (this.scene.clicked && isMouseWithinTriangle(this.scene.clickX, this.scene.clickY, screenYNE, screenYNW, screenYSE, screenXNE, screenXNW, screenXSE)) {
                 this.scene.clickedTileX = tileX;
                 this.scene.clickedTileY = tileY;
             }
-            if (isMouseWithinTriangle(MouseHandler.mouseX, MouseHandler.mouseY, screenYD, screenYC, screenYB, screenXD, screenXC, screenXB)) {
+            if (isMouseWithinTriangle(MouseHandler.mouseX, MouseHandler.mouseY, screenYNE, screenYNW, screenYSE, screenXNE, screenXNW, screenXSE)) {
                 this.scene.hoveredTileX = tileX;
                 this.scene.hoveredTileY = tileY;
             }
             if (plainTile.texture == -1) {
                 if (plainTile.colourD != 12345678) {
-                    Rasterizer3D.drawShadedTriangle(screenYD, screenYC, screenYB, screenXD, screenXC, screenXB, plainTile.colourD, plainTile.colourC, plainTile.colourB);
+                    Rasterizer3D.drawShadedTriangle(screenYNE, screenYNW, screenYSE, screenXNE, screenXNW, screenXSE, plainTile.colourD, plainTile.colourC, plainTile.colourB);
                 }
             } else if (Scene.lowMemory) {
                 int rgb = Rasterizer3D.interface3.getAverageTextureColour(plainTile.texture);
-                Rasterizer3D.drawShadedTriangle(screenYD, screenYC, screenYB, screenXD, screenXC, screenXB, Scene.adjustLightness(rgb, plainTile.colourD), Scene.adjustLightness(rgb, plainTile.colourC), Scene.adjustLightness(rgb, plainTile.colourB));
+                Rasterizer3D.drawShadedTriangle(screenYNE, screenYNW, screenYSE, screenXNE, screenXNW, screenXSE, Scene.adjustLightness(rgb, plainTile.colourD), Scene.adjustLightness(rgb, plainTile.colourC), Scene.adjustLightness(rgb, plainTile.colourB));
             } else if (plainTile.flat) {
-                Rasterizer3D.drawTexturedTriangle(screenYD, screenYC, screenYB, screenXD, screenXC, screenXB, plainTile.colourD, plainTile.colourC, plainTile.colourB, xA, xB, xC, zA, zB, zD, yA, yB, yC, plainTile.texture);
+                Rasterizer3D.drawTexturedTriangle(screenYNE, screenYNW, screenYSE, screenXNE, screenXNW, screenXSE, plainTile.colourD, plainTile.colourC, plainTile.colourB, swX, seX, nwX, swZ, seZ, nwZ, swY, seY, nwY, plainTile.texture);
             } else {
-                Rasterizer3D.drawTexturedTriangle(screenYD, screenYC, screenYB, screenXD, screenXC, screenXB, plainTile.colourD, plainTile.colourC, plainTile.colourB, xD, xC, xB, zC, zD, zB, yD, yC, yB, plainTile.texture);
+                Rasterizer3D.drawTexturedTriangle(screenYNE, screenYNW, screenYSE, screenXNE, screenXNW, screenXSE, plainTile.colourD, plainTile.colourC, plainTile.colourB, neX, nwX, seX, neZ, nwZ, seZ, neY, nwY, seY, plainTile.texture);
             }
         }
-        if ((screenXA - screenXB) * (screenYC - screenYB) - (screenYA - screenYB) * (screenXC - screenXB) > 0) {
-            Rasterizer3D.restrict_edges = screenXA < 0 || screenXB < 0 || screenXC < 0 || screenXA > Rasterizer3D.viewportRx || screenXB > Rasterizer3D.viewportRx || screenXC > Rasterizer3D.viewportRx;
-            if (this.scene.clicked && isMouseWithinTriangle(this.scene.clickX, this.scene.clickY, screenYA, screenYB, screenYC, screenXA, screenXB, screenXC)) {
+        if ((screenXSW - screenXSE) * (screenYNW - screenYSE) - (screenYSW - screenYSE) * (screenXNW - screenXSE) > 0) {
+            Rasterizer3D.restrict_edges = screenXSW < 0 || screenXSE < 0 || screenXNW < 0 || screenXSW > Rasterizer3D.viewportRx || screenXSE > Rasterizer3D.viewportRx || screenXNW > Rasterizer3D.viewportRx;
+            if (this.scene.clicked && isMouseWithinTriangle(this.scene.clickX, this.scene.clickY, screenYSW, screenYSE, screenYNW, screenXSW, screenXSE, screenXNW)) {
                 this.scene.clickedTileX = tileX;
                 this.scene.clickedTileY = tileY;
             }
 
-            if (isMouseWithinTriangle(MouseHandler.mouseX, MouseHandler.mouseY, screenYA, screenYB, screenYC, screenXA, screenXB, screenXC)) {
+            if (isMouseWithinTriangle(MouseHandler.mouseX, MouseHandler.mouseY, screenYSW, screenYSE, screenYNW, screenXSW, screenXSE, screenXNW)) {
                 this.scene.hoveredTileX = tileX;
                 this.scene.hoveredTileY = tileY;
             }
             if (plainTile.texture == -1) {
                 if (plainTile.colourA != 12345678) {
-                    Rasterizer3D.drawShadedTriangle(screenYA, screenYB, screenYC, screenXA, screenXB, screenXC, plainTile.colourA, plainTile.colourB, plainTile.colourC);
+                    Rasterizer3D.drawShadedTriangle(screenYSW, screenYSE, screenYNW, screenXSW, screenXSE, screenXNW, plainTile.colourA, plainTile.colourB, plainTile.colourC);
                 }
             } else if (Scene.lowMemory) {
                 int i_209_ = Rasterizer3D.interface3.getAverageTextureColour(plainTile.texture);
-                Rasterizer3D.drawShadedTriangle(screenYA, screenYB, screenYC, screenXA, screenXB, screenXC, Scene.adjustLightness(i_209_, plainTile.colourA), Scene.adjustLightness(i_209_, plainTile.colourB), Scene.adjustLightness(i_209_, plainTile.colourC));
+                Rasterizer3D.drawShadedTriangle(screenYSW, screenYSE, screenYNW, screenXSW, screenXSE, screenXNW, Scene.adjustLightness(i_209_, plainTile.colourA), Scene.adjustLightness(i_209_, plainTile.colourB), Scene.adjustLightness(i_209_, plainTile.colourC));
             } else {
-                Rasterizer3D.drawTexturedTriangle(screenYA, screenYB, screenYC, screenXA, screenXB, screenXC, plainTile.colourA, plainTile.colourB, plainTile.colourC, xA, xB, xC, zA, zB, zD, yA, yB, yC, plainTile.texture);
+                Rasterizer3D.drawTexturedTriangle(screenYSW, screenYSE, screenYNW, screenXSW, screenXSE, screenXNW, plainTile.colourA, plainTile.colourB, plainTile.colourC, swX, seX, nwX, swZ, seZ, nwZ, swY, seY, nwY, plainTile.texture);
             }
         }
     }

--- a/src/main/java/org/runejs/client/scene/Util3d.java
+++ b/src/main/java/org/runejs/client/scene/Util3d.java
@@ -1,0 +1,43 @@
+package org.runejs.client.scene;
+
+import org.runejs.client.scene.camera.Camera;
+
+public class Util3d {
+    /**
+     * Applies the camera's yaw and pitch rotation to a point in 3D space.
+     * If the y-coordinate of the rotated point is less than 50, the function returns null,
+     * indicating that the point should not be processed further.
+     *
+     * @param x The x-coordinate of a point.
+     * @param y The y-coordinate of a point.
+     * @param z The z-coordinate of a point.
+     * @param currentCamera The camera object with rotation (yaw and pitch) information.
+     * @return An array of three integers representing the transformed x, y, z coordinates,
+     *         or null if the y-coordinate of the rotated point is less than 50.
+     */
+    public static int[] getProjectedPoint(Camera camera, int x, int y, int z) {
+        // Get the sine and cosine of the camera's yaw and pitch rotations
+        int sinX = camera.getRotation().yawSine;
+        int cosineX = camera.getRotation().yawCosine;
+        int sinY = camera.getRotation().pitchSine;
+        int cosineY = camera.getRotation().pitchCosine;
+
+        // Apply the yaw rotation to the point
+        int temp = (y * sinX + x * cosineX) >> 16;
+        y = (y * cosineX - x * sinX) >> 16;
+        x = temp;
+
+        // Apply the pitch rotation to the point
+        temp = (z * cosineY - y * sinY) >> 16;
+        y = (z * sinY + y * cosineY) >> 16;
+        z = temp;
+
+        // If the y-coordinate of the rotated point is less than 50, return null
+        if (y < 50) {
+            return null;
+        }
+
+        // Return the transformed point
+        return new int[]{x, y, z};
+    }
+}

--- a/src/main/java/org/runejs/client/scene/tile/GenericTile.java
+++ b/src/main/java/org/runejs/client/scene/tile/GenericTile.java
@@ -2,18 +2,18 @@ package org.runejs.client.scene.tile;
 
 public class GenericTile {
     public int texture;
-    public int colourB;
+    public int colourSE;
     public int rgbColor;
     public boolean flat;
-    public int colourA;
-    public int colourC;
-    public int colourD;
+    public int colourSW;
+    public int colourNW;
+    public int colourNE;
 
-    public GenericTile(int colourA, int colourB, int colourC, int colourD, int texture, int rgbColor, boolean flat) {
-        this.colourA = colourA;
-        this.colourB = colourB;
-        this.colourC = colourC;
-        this.colourD = colourD;
+    public GenericTile(int colourSW, int colourSE, int colourNW, int colourNE, int texture, int rgbColor, boolean flat) {
+        this.colourSW = colourSW;
+        this.colourSE = colourSE;
+        this.colourNW = colourNW;
+        this.colourNE = colourNE;
         this.texture = texture;
         this.rgbColor = rgbColor;
         this.flat = flat;


### PR DESCRIPTION
We use `A`/`B`/`C`/`D` to talk about corners of tiles quite a bit, we should rename them to NE/NW/SE/SW.