### PR TITLE
Add "Teleport here" menu option when in debug mode and player is admin

### DIFF
--- a/src/main/java/org/runejs/client/ActionRowType.java
+++ b/src/main/java/org/runejs/client/ActionRowType.java
@@ -7,7 +7,7 @@ package org.runejs.client;
  * These codes are used to determine the behaviour associated with a row
  * when a user clicks on it (or when a user left-clicks the entity, if the
  * row is the highest priority).
- * 
+ *
  * @author jameskmonger
  */
 public enum ActionRowType {
@@ -41,6 +41,11 @@ public enum ActionRowType {
      * Walk to a tile.
      */
     WALK_HERE(7),
+
+    /**
+     * Teleport to a tile.
+     */
+    TELEPORT_HERE(1009),
 
     /**
      * Drop an item from the inventory.
@@ -86,10 +91,10 @@ public enum ActionRowType {
      * Report a player for abuse.
      */
     REPORT_ABUSE(28),
-    
+
     /**
      * The initial 'use' to select an item on a widget
-     * 
+     *
      * TODO TODO TODO is this inventory or widget ??
      */
     SELECT_ITEM_ON_WIDGET(19),
@@ -138,7 +143,7 @@ public enum ActionRowType {
 
     /**
      * Cast a spell on a widget item.
-     * 
+     *
      * TODO TODO TODO inventory or widget?
      */
     CAST_MAGIC_ON_WIDGET_ITEM(37),
@@ -157,28 +162,28 @@ public enum ActionRowType {
      * Interact with a player and choose option 1.
      */
     INTERACT_WITH_PLAYER_OPTION_1(10),
-    
+
     /**
      * Interact with a player and choose option 2.
      */
     INTERACT_WITH_PLAYER_OPTION_2(39),
-    
+
     /**
      * Interact with a player and choose option 3.
      */
     INTERACT_WITH_PLAYER_OPTION_3(44),
-    
+
     /**
      * Interact with a player and choose option 4.
      */
     INTERACT_WITH_PLAYER_OPTION_4(14),
-    
+
     /**
      * Interact with a player and choose option 5.
      */
     INTERACT_WITH_PLAYER_OPTION_5(41),
 
-    
+
     /**
      * Interact with an NPC and choose option 1.
      *
@@ -212,17 +217,17 @@ public enum ActionRowType {
      * Interact with an object and choose option 1.
      */
     INTERACT_WITH_OBJECT_OPTION_1(16),
-    
+
     /**
      * Interact with an object and choose option 2.
      */
     INTERACT_WITH_OBJECT_OPTION_2(29),
-    
+
     /**
      * Interact with an object and choose option 3.
      */
     INTERACT_WITH_OBJECT_OPTION_3(17),
-    
+
     /**
      * Interact with an object and choose option 4.
      */
@@ -244,17 +249,17 @@ public enum ActionRowType {
      * Interact with a world item and choose option 2.
      */
     INTERACT_WITH_WORLD_ITEM_OPTION_2(38),
-    
+
     /**
      * Interact with a world item and choose option 3.
      */
     INTERACT_WITH_WORLD_ITEM_OPTION_3(3),
-    
+
     /**
      * Interact with a world item and choose option 4.
      */
     INTERACT_WITH_WORLD_ITEM_OPTION_4(8),
-    
+
     /**
      * Interact with a world item and choose option 5.
      */
@@ -262,7 +267,7 @@ public enum ActionRowType {
 
     /**
      * Interact with an item on a V1 widget and choose option 1.
-     * 
+     *
      * For example, the left-click option on an item on a shop interface.
      */
     INTERACT_WITH_ITEM_ON_V1_WIDGET_OPTION_1(53),
@@ -275,10 +280,10 @@ public enum ActionRowType {
      * Interact with an item on a V1 widget and choose option 2.
      */
     INTERACT_WITH_ITEM_ON_V2_WIDGET_OPTION_1(52),
-    
+
     /**
      * Interact with an item on a V1 widget and choose option 3.
-     * 
+     *
      * (jameskmongeR) this one is read on the server as 'option 5' - which is correct?
      */
     INTERACT_WITH_ITEM_ON_V2_WIDGET_OPTION_2(6),
@@ -287,7 +292,7 @@ public enum ActionRowType {
      * Interact with an item on a V1 widget and choose option 3.
      */
     INTERACT_WITH_ITEM_ON_V2_WIDGET_OPTION_3(31),
-    
+
     /**
      * Interact with an item on a V1 widget and choose option 4.
      */
@@ -297,7 +302,7 @@ public enum ActionRowType {
      * Examine an NPC.
      */
     EXAMINE_NPC(1001),
-    
+
     /**
      * Examine an item.
      */
@@ -327,7 +332,7 @@ public enum ActionRowType {
      * TODO (Jameskmonger) document this
      */
     CLOSE_WIDGET(9),
-    
+
     /**
      * TODO (Jameskmonger) document this
      */
@@ -338,7 +343,7 @@ public enum ActionRowType {
     /**
      * Used to mark actions that are lower priority, i.e.
      * they should be displayed lower in the menu.
-     * 
+     *
      * This is used to ensure that left-click is not "Attack" on
      * high-level NPCs, for example.
      */

--- a/src/main/java/org/runejs/client/MovedStatics.java
+++ b/src/main/java/org/runejs/client/MovedStatics.java
@@ -642,7 +642,7 @@ public class MovedStatics {
     public static int mixLightnessSigned(int hsl, int lightness) {
         if (hsl == -2)
             return 12345678;
-            
+
         if (hsl == -1) {
             if (lightness < 0)
                 lightness = 0;
@@ -666,8 +666,10 @@ public class MovedStatics {
             String tileCoords = "";
             if (Configuration.DEBUG_CONTEXT) {
                 tileCoords = MessageFormat.format("<col=8F8FFF>({0}, {1})</col>", Integer.toString(Game.currentScene.hoveredTileX + baseX), Integer.toString(Game.currentScene.hoveredTileY + baseY));
+                if (Game.playerRights >= 2) {
+                    addActionRow(English.teleportHere, 0, (Game.currentScene.hoveredTileX + baseX), (Game.currentScene.hoveredTileY + baseY), ActionRowType.TELEPORT_HERE.getId(), tileCoords);
+                }
             }
-
             addActionRow(English.walkHere, 0, MouseHandler.mouseX, MouseHandler.mouseY, ActionRowType.WALK_HERE.getId(), tileCoords);
         }
 
@@ -1004,7 +1006,7 @@ public class MovedStatics {
 	                    if(gameInterface.buttonType == 6 && lastContinueTextWidgetId == -1 && adjustedX <= mouseX && adjustedY <= mouseY && mouseX < adjustedX + gameInterface.width && mouseY < gameInterface.height + adjustedY) {
 	                        addActionRow(gameInterface.option, 0, 0, gameInterface.id, 54, "");
 	                    }
-	
+
 	                    if(gameInterface.type == GameInterfaceType.INVENTORY) {
 	                        int i_4_ = 0;
 	                        for(int i_5_ = 0; i_5_ < gameInterface.height; i_5_++) {
@@ -1146,13 +1148,13 @@ public class MovedStatics {
 	            }
 	        }
 	    }
-	
+
 	}
 
     public static void setHighMemory() {
 	    VertexNormal.lowMemory = false;
 	    Scene.lowMemory = false;
-	
+
 	}
 
 	public static void animateNpcs() {
@@ -1162,7 +1164,7 @@ public class MovedStatics {
 	        if(class40_sub5_sub17_sub4_sub2 != null)
 	            Actor.handleActorAnimation(class40_sub5_sub17_sub4_sub2);
 	    }
-	
+
 	}
 
 
@@ -1273,7 +1275,7 @@ public class MovedStatics {
 	                break;
 	            Game.oneMouseButton = varPlayerValue;
 	        }
-	
+
 	        break;
 	    } while(false);
 	}

--- a/src/main/java/org/runejs/client/cache/media/gameInterface/GameInterface.java
+++ b/src/main/java/org/runejs/client/cache/media/gameInterface/GameInterface.java
@@ -23,6 +23,7 @@ import org.runejs.client.media.renderable.actor.Pathfinding;
 import org.runejs.client.media.renderable.actor.Player;
 import org.runejs.client.media.renderable.actor.PlayerAppearance;
 import org.runejs.client.message.outbound.chat.*;
+import org.runejs.client.message.outbound.console.ConsoleCommandOutboundMessage;
 import org.runejs.client.message.outbound.examine.*;
 import org.runejs.client.message.outbound.interactions.*;
 import org.runejs.client.message.outbound.magic.*;
@@ -629,6 +630,10 @@ public class GameInterface extends CachedNode {
                     atInventoryInterfaceType = 3;
                 }
             }
+            if(action == ActionRowType.TELEPORT_HERE.getId()) {
+                ConsoleCommandOutboundMessage newCmd = new ConsoleCommandOutboundMessage("move "+i + " "+i_10_);
+                OutgoingPackets.sendMessage(newCmd);
+            }
             if(action == ActionRowType.INTERACT_WITH_WORLD_ITEM_OPTION_2.getId()) {
                 Pathfinding.doWorldItemWalkTo(Player.localPlayer.pathY[0], Player.localPlayer.pathX[0], i, i_10_);
                 MovedStatics.crossIndex = 0;
@@ -867,7 +872,7 @@ public class GameInterface extends CachedNode {
                     MovedStatics.crossType = 2;
                     crossY = MouseHandler.clickY;
                     MovedStatics.crossIndex = 0;
-                    
+
                     int widgetId = (itemSelectedWidgetId >> 16) & 0xFFFF;
                     int containerId = itemSelectedWidgetId & 0xFFFF;
 

--- a/src/main/java/org/runejs/client/language/English.java
+++ b/src/main/java/org/runejs/client/language/English.java
@@ -110,6 +110,7 @@ public class English {
     public static String unexpectedServerResponse = "Unexpected server response";
     public static String username = "Username: ";
     public static String walkHere = "Walk here";
+    public static String teleportHere = "Teleport here";
     public static String weSuspectSomeoneKnowsYourPassword = "We suspect someone knows your password.";
     public static String suffixWishesToDuelWithYou = "wishes to duel with you.";
     public static String world = "World";


### PR DESCRIPTION
Just like the title says - this adds a Teleport Here option, but only if the player is an admin and debug mode is enabled in the client config.

When clicked, the menu item sends a console command to the server (`move x y`).

![2024-09-04-08-19-48](https://github.com/user-attachments/assets/fadbad52-1de6-488a-9d6e-e72793a2a3ec)
