### PR TITLE
Add github actions workflow to build & release when tag events occur

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -1,0 +1,47 @@
+name: Build and publish artifacts
+
+on:
+  push:
+    branches:
+      - master
+    tags:
+      - "v*"
+
+permissions:
+  contents: write # Required to create releases and modify repository contents
+  deployments: write # Required for creating deployments associated with releases
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v4
+
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: "adopt"
+          java-version: 8
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Build with Gradle
+        run: ./gradlew jar
+
+      # https://github.com/marketplace/actions/create-release
+      #
+      # This will only get triggered when creating a tag, such as via the
+      # commands:
+      #
+      # git tag -a v0.0.1 && git push origin v0.0.1
+      #
+      # For good measure, tags should be signed with your GPG key, such as:
+      #
+      # git tag -s -a v0.0.1 && git push origin v0.0.1
+      - uses: ncipollo/release-action@v1
+        if: startsWith(github.ref, 'refs/tags/v')
+        with:
+          artifacts: "build/libs/*.jar"
+          bodyFile: ".github/workflows/release-body.md"

--- a/.github/workflows/release-body.md
+++ b/.github/workflows/release-body.md
@@ -1,0 +1,11 @@
+# Release notes
+
+For your convenience, we provide Java `.jar` file builds that can connect to the [server](https://github.com/runejs/server).
+
+## Instructions
+
+To run the client, follow the steps in the [`README.md` file](https://github.com/runejs/refactored-client-435) - make sure to change the name of the `.jar` file to match your downloaded file name if needed:
+
+```bash
+java -jar path/to/your/downloaded/client-435-0.3.jar
+```


### PR DESCRIPTION
Adds a GitHub Actions workflow that attempts a gradle build upon receiving a git `tag` event. If the build succeeds, a release will be created.

It also does a build upon commits to master.

I have tested this in an independent repository, seen here: 

- https://github.com/charles-m-knox/actions-test
- https://github.com/charles-m-knox/actions-test/actions
- https://github.com/charles-m-knox/actions-test/releases
