### PR TITLE
Add shift+click to drop

### DIFF
--- a/config/client-435.conf.example.yaml
+++ b/config/client-435.conf.example.yaml
@@ -14,4 +14,5 @@ game:
   roofsEnabled: true
   freeTeleports: false
   debugContextMenu: true
+  shiftClickModifier: true
 serverDisplayName: Build 435

--- a/src/main/java/org/runejs/Configuration.java
+++ b/src/main/java/org/runejs/Configuration.java
@@ -39,6 +39,7 @@ public class Configuration {
             USERNAME = (String) login.get("username");
             PASSWORD = (String) login.get("password");
             ROOFS_ENABLED = (boolean) game.get("roofsEnabled");
+            SHIFT_CLICK_MODIFIER = (boolean) game.get("shiftClickModifier");
             SOUND_MUTED = (boolean) game.get("soundMuted");
             FREE_TELEPORTS = (boolean) game.get("freeTeleports");
             DEBUG_CONTEXT = (boolean) game.get("debugContextMenu");
@@ -51,7 +52,7 @@ public class Configuration {
             if (PASSWORD == null) {
                 PASSWORD = "";
             }
-            
+
             if (SERVER_DISPLAY_NAME == null) {
                 SERVER_DISPLAY_NAME = "Build 435";
             }
@@ -78,6 +79,7 @@ public class Configuration {
 
             Map<String, Object> game = new HashMap<String, Object>();
             game.put("roofsEnabled", ROOFS_ENABLED);
+            game.put("shiftClickModifier", SHIFT_CLICK_MODIFIER);
             game.put("freeTeleports", FREE_TELEPORTS);
             game.put("debugContextMenu", DEBUG_CONTEXT);
             game.put("soundMuted", SOUND_MUTED);
@@ -171,6 +173,13 @@ public class Configuration {
      * Do you want to render roofs
      */
     public static boolean ROOFS_ENABLED = true;
+
+    /**
+     * If true, the shift key will cause the second-highest menu item to be
+     * shown instead of the first, and if there is a "Drop" value present, it
+     * will be prioritized.
+     */
+    public static boolean SHIFT_CLICK_MODIFIER = true;
 
     /**
      * Always light up teleports

--- a/src/main/java/org/runejs/client/Game.java
+++ b/src/main/java/org/runejs/client/Game.java
@@ -116,6 +116,14 @@ public class Game {
     public static int playerRights = 0;
     public static Timer gameTimer;
     public static int idleLogout = 0;
+
+    /**
+     * If the shift key has been pressed, this reflects the state, but only
+     * `Game.isShiftModifierActive()` should be used for confirming that the key
+     * is pressed as well as checking that player's client's configuration
+     * allows shift modifiers to be leveraged.
+     */
+    public static boolean shiftPressed = false;
     /**
      * Backup port if the first one fails?
      */
@@ -990,7 +998,7 @@ public class Game {
                 ChatBox.redrawChatbox = true;
             }
         }
-        
+
         if(flashingTabId != -1) {
             GameInterface.drawTabIcons = true;
         }
@@ -2057,5 +2065,15 @@ public class Game {
         if (modewhere != 0)
             MovedStatics.showFps = true;
         chatboxInterface = new GameInterface();
+    }
+
+    /**
+     * Checks if the shift modifiers are enabled and active.
+     *
+     * @return true if the player is currently pressing the shift key and if
+     * player has configured their client to accept shift modifiers.
+     */
+    public static boolean isShiftModifierActive() {
+        return Game.shiftPressed == true && Configuration.SHIFT_CLICK_MODIFIER;
     }
 }

--- a/src/main/java/org/runejs/client/frame/ScreenController.java
+++ b/src/main/java/org/runejs/client/frame/ScreenController.java
@@ -386,9 +386,13 @@ public class ScreenController {
             int destX = Player.localPlayer.worldX + i_14_ >> 7;
             int destY = -i_15_ + Player.localPlayer.worldY >> 7;
 
+            // if the player is a mod or admin, and the shift key is pressed,
+            // this will send a console command to the server to teleport the
+            // player. This predates the shift key modifiers
+            // added on 2024-09-04.
             if (MovedStatics.obfuscatedKeyStatus[81] && Game.playerRights > 1) {
                 OutgoingPackets.buffer.putPacket(246);
-                OutgoingPackets.buffer.putString(MessageFormat.format(" move {0} {1}", Integer.toString(destX + MovedStatics.baseX), Integer.toString(destY + MovedStatics.baseY)));
+                OutgoingPackets.buffer.putString(MessageFormat.format("{0} {1} {2}", "move", Integer.toString(destX + MovedStatics.baseX), Integer.toString(destY + MovedStatics.baseY)));
             } else {
                 Pathfinding.MinimapWalkAnalytics analytics = new Pathfinding.MinimapWalkAnalytics(
                     minimapClickX,
@@ -405,9 +409,9 @@ public class ScreenController {
                 );
 
                 Pathfinding.doMinimapWalkTo(
-                    Player.localPlayer.pathY[0], 
-                    Player.localPlayer.pathX[0], 
-                    destX, 
+                    Player.localPlayer.pathY[0],
+                    Player.localPlayer.pathX[0],
+                    destX,
                     destY,
                     analytics
                 );

--- a/src/main/java/org/runejs/client/input/KeyFocusListener.java
+++ b/src/main/java/org/runejs/client/input/KeyFocusListener.java
@@ -132,6 +132,9 @@ public class KeyFocusListener implements KeyListener, FocusListener {
             } else {
                 keyChar = getKeyChar(keyEvent);
             }
+            if (eventKeyCode == KeyEvent.VK_SHIFT) {
+                Game.shiftPressed = true;
+            }
             if (eventKeyCode == 192 || eventKeyCode == 129) {
                 Console.console.consoleOpen = !Console.console.consoleOpen;
             }
@@ -159,11 +162,16 @@ public class KeyFocusListener implements KeyListener, FocusListener {
             framesSinceKeyboardInput = 0;
             int i = arg0.getKeyCode();
 
+            if (i == KeyEvent.VK_SHIFT) {
+                Game.shiftPressed = false;
+            }
+
             if (i < 0 || OBFUSCATED_KEY_CODES.length <= i) {
                 i = -1;
             } else {
                 i = ~0x80 & OBFUSCATED_KEY_CODES[i];
             }
+
             if (anInt2543 >= 0 && i >= 0) {
                 MovedStatics.keyCodes[anInt2543] = i ^ 0xffffffff;
                 anInt2543 = 0x7f & 1 + anInt2543;


### PR DESCRIPTION
Adds a configurable option to shift+click to drop. If `drop` is not available as a menu item, then holding shift will revert to the second highest priority item in the menu.

other minor changes:

- whitespace/minor formatting cleanup
- renamed one or two obvious tokens in the source code that probably came from deobfuscation