### PR TITLE
Add vscode workspace setting to ignore autoformatting in java files

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,8 @@
+{
+    // do not autoformat java files in this repository
+    "[java]": {
+        "editor.formatOnSave": false,
+        "editor.formatOnPaste": false,
+        "editor.formatOnType": false,
+    },
+}


### PR DESCRIPTION
Adds a vscode IDE configuration option that tells the Java plugin to disable autoformat on save. This is to prevent massive diffs from future contributors working with vscode.